### PR TITLE
feat: add automate creation test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,6 +735,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "cairo-lint-dev"
+version = "0.1.0"
+
+[[package]]
 name = "cairo-lint-test-utils"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/cairo-lint-cli", "crates/cairo-lint-core", "crates/cairo-lint-test-utils"]
+members = ["crates/cairo-lint-cli", "crates/cairo-lint-core", "crates/cairo-lint-dev", "crates/cairo-lint-test-utils"]
 
 [workspace.package]
 version = "0.1.0"

--- a/crates/cairo-lint-core/tests/test_files/double_parsen
+++ b/crates/cairo-lint-core/tests/test_files/double_parsen
@@ -1,0 +1,6 @@
+//! > Test name
+
+//! > cairo_code
+fn main() {
+    let a: Option<felt252> = Option::Some(1);
+}

--- a/crates/cairo-lint-core/tests/tests.rs
+++ b/crates/cairo-lint-core/tests/tests.rs
@@ -30,3 +30,5 @@ test_file!(
     "nested destructuring match twisted differently",
     "nested destructuring match second arm"
 );
+
+test_file!(double_parsen, "Test name");

--- a/crates/cairo-lint-dev/Cargo.toml
+++ b/crates/cairo-lint-dev/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "cairo-lint-dev"
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+license-file.workspace = true
+
+[dependencies]
+
+[[bin]]
+name = "create_test"
+path = "src/main.rs"

--- a/crates/cairo-lint-dev/src/main.rs
+++ b/crates/cairo-lint-dev/src/main.rs
@@ -1,0 +1,54 @@
+use std::fs;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+fn create_new_test(lint_name: &str) -> io::Result<()> {
+    let test_content = format!(
+        "//! > Test name\n\n//! > cairo_code\nfn main() {{\n    let a: Option<felt252> = Option::Some(1);\n}}\n"
+    );
+
+    let test_files_dir = PathBuf::from("crates/cairo-lint-core/tests/test_files");
+    if !test_files_dir.exists() {
+        fs::create_dir_all(&test_files_dir)?;
+    }
+
+    let file_name = test_files_dir.join(lint_name);
+
+    let mut file = fs::File::create(&file_name)?;
+    file.write_all(test_content.as_bytes())?;
+
+    println!("Test file created: {}", file_name.display());
+
+    let tests_rs_path = Path::new("crates/cairo-lint-core/tests/tests.rs");
+
+    if !tests_rs_path.exists() {
+        eprintln!("Error: tests.rs file not found!");
+        return Ok(());
+    }
+
+    let new_test_entry = format!(r#"test_file!({}, "Test name");"#, lint_name);
+
+    let mut tests_rs_content = fs::read_to_string(tests_rs_path)?;
+    tests_rs_content.push_str("\n");
+    tests_rs_content.push_str(&new_test_entry);
+    fs::write(tests_rs_path, tests_rs_content)?;
+
+    println!("Test entry added to tests.rs");
+
+    Ok(())
+}
+
+fn main() {
+    let lint_name = if let Some(arg1) = std::env::args().nth(1) {
+        arg1
+    } else {
+        println!("Enter the name of the lint:");
+        let mut lint_name = String::new();
+        io::stdin().read_line(&mut lint_name).expect("Failed to read line");
+        lint_name.trim().to_string()
+    };
+
+    if let Err(e) = create_new_test(&lint_name) {
+        eprintln!("Error creating test file: {}", e);
+    }
+}


### PR DESCRIPTION
### Summary 📌
This PR introduces a utility tool named `create_test` that automates the creation of test files for new lints. 

### Changes Made ⚡️

#### Creation of `cairo-lint-dev`

- **Implemented a simple CLI tool** in `cairo-lint-dev` that automates the creation of new test files.
- The tool supports two modes of operation:
  - **Command-line Argument:** The user can pass the lint name directly as an argument.
  - **Interactive Prompt:** If no argument is provided, the tool prompts the user to enter the lint name.
- The tool generates a test file with a standard structure and appends the appropriate entry to `tests.rs` for immediate inclusion in the test suite.

### Justification & Future Improvements 🛠️

- **Current Stage:** The project is in its early stages, and this tool provides a quick and effective way to maintain consistency in test creation.
- **Future Scalability:** As the project grows, this tool can be refactored to incorporate more robust features using libraries like `clap` for argument parsing and additional error handling. This would provide a more scalable solution as the project matures.

### Test Results ✅

- The tool was tested by generating multiple test files, ensuring that both the test files and their corresponding entries in `tests.rs` were created correctly.

![image](https://github.com/user-attachments/assets/126aa1f1-4f16-4437-9d61-ee39027a4f42)
![image](https://github.com/user-attachments/assets/e8e1501b-e7c5-4fed-99e9-d58a922143e6)
![image](https://github.com/user-attachments/assets/5b9f2a71-0e52-4b88-beea-1a054c594da1)


### Usage Instructions 📄

Make sure you are in the root path of the project
To use the `cairo-lint-dev` tool, you can follow these steps:

1. **With a command-line argument:**
   ```bash
   cargo run --bin create_test <lint_name>

2. **With a prompt:**
   ```bash
   cargo run --bin create_test