### PR TITLE
feat: lint multiple unused imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1711,6 +1711,7 @@ dependencies = [
  "cairo-lang-filesystem",
  "cairo-lang-semantic",
  "cairo-lang-starknet",
+ "cairo-lang-syntax",
  "cairo-lang-test-plugin",
  "cairo-lang-utils",
  "cairo-lint-core",

--- a/crates/cairo-lint-cli/Cargo.toml
+++ b/crates/cairo-lint-cli/Cargo.toml
@@ -15,6 +15,7 @@ cairo-lang-utils.workspace = true
 cairo-lang-semantic.workspace = true
 cairo-lang-filesystem.workspace = true
 cairo-lang-diagnostics.workspace = true
+cairo-lang-syntax.workspace = true
 cairo-lang-test-plugin.workspace = true
 cairo-lang-defs.workspace = true
 cairo-lang-starknet.workspace = true

--- a/crates/cairo-lint-cli/src/main.rs
+++ b/crates/cairo-lint-cli/src/main.rs
@@ -145,8 +145,8 @@ fn main_inner(ui: &Ui, args: Args) -> Result<()> {
                 collect_unused_imports(&db, &diagnostics);
             let mut fixes = HashMap::new();
             unused_imports.keys().for_each(|file_id| {
-                let mut file_fixes: Vec<Fix> = apply_import_fixes(&db, unused_imports.get(file_id).unwrap());
-                fixes.insert(file_id.clone(), file_fixes);
+                let file_fixes: Vec<Fix> = apply_import_fixes(&db, unused_imports.get(file_id).unwrap());
+                fixes.insert(*file_id, file_fixes);
             });
 
             let diags_without_imports = diagnostics
@@ -155,7 +155,7 @@ fn main_inner(ui: &Ui, args: Args) -> Result<()> {
                 .collect::<Vec<_>>();
 
             for diag in diags_without_imports {
-                if let Some((fix_node, fix)) = fix_semantic_diagnostic(&db, &diag) {
+                if let Some((fix_node, fix)) = fix_semantic_diagnostic(&db, diag) {
                     let location = diag.location(db.upcast());
                     fixes
                         .entry(location.file_id)

--- a/crates/cairo-lint-cli/src/main.rs
+++ b/crates/cairo-lint-cli/src/main.rs
@@ -13,12 +13,14 @@ use cairo_lang_diagnostics::DiagnosticEntry;
 use cairo_lang_filesystem::db::{init_dev_corelib, FilesGroup, CORELIB_CRATE_NAME};
 use cairo_lang_filesystem::ids::{CrateLongId, FileId};
 use cairo_lang_semantic::db::SemanticGroup;
+use cairo_lang_semantic::diagnostic::SemanticDiagnosticKind;
 use cairo_lang_semantic::inline_macros::get_default_plugin_suite;
 use cairo_lang_starknet::starknet_plugin_suite;
+use cairo_lang_syntax::node::SyntaxNode;
 use cairo_lang_test_plugin::test_plugin_suite;
 use cairo_lang_utils::{Upcast, UpcastMut};
 use cairo_lint_core::diagnostics::format_diagnostic;
-use cairo_lint_core::fix::{fix_semantic_diagnostic, Fix};
+use cairo_lint_core::fix::{apply_import_fixes, collect_unused_imports, fix_semantic_diagnostic, Fix, ImportFix};
 use cairo_lint_core::plugin::cairo_lint_plugin_suite;
 use clap::Parser;
 use helpers::*;
@@ -137,8 +139,22 @@ fn main_inner(ui: &Ui, args: Args) -> Result<()> {
             .collect::<Vec<_>>();
 
         if args.fix {
+            // Handling unused imports separately as we need to run pre-analysis on the diagnostics.
+            // to handle complex cases.
+            let unused_imports: HashMap<FileId, HashMap<SyntaxNode, ImportFix>> =
+                collect_unused_imports(&db, &diagnostics);
             let mut fixes = HashMap::new();
-            for diag in diagnostics {
+            unused_imports.keys().for_each(|file_id| {
+                let mut file_fixes: Vec<Fix> = apply_import_fixes(&db, unused_imports.get(file_id).unwrap());
+                fixes.insert(file_id.clone(), file_fixes);
+            });
+
+            let diags_without_imports = diagnostics
+                .iter()
+                .filter(|diag| !matches!(diag.kind, SemanticDiagnosticKind::UnusedImport(_)))
+                .collect::<Vec<_>>();
+
+            for diag in diags_without_imports {
                 if let Some((fix_node, fix)) = fix_semantic_diagnostic(&db, &diag) {
                     let location = diag.location(db.upcast());
                     fixes

--- a/crates/cairo-lint-core/src/fix.rs
+++ b/crates/cairo-lint-core/src/fix.rs
@@ -1,6 +1,9 @@
+use std::collections::HashMap;
+
 use cairo_lang_compiler::db::RootDatabase;
 use cairo_lang_defs::ids::UseId;
 use cairo_lang_defs::plugin::PluginDiagnostic;
+use cairo_lang_diagnostics::Diagnostics;
 use cairo_lang_filesystem::span::TextSpan;
 use cairo_lang_semantic::diagnostic::SemanticDiagnosticKind;
 use cairo_lang_semantic::SemanticDiagnostic;
@@ -23,6 +26,14 @@ pub struct Fix {
     pub suggestion: String,
 }
 
+#[derive(Debug, Clone)]
+pub struct ImportFix {
+    // The node that contains the imports to be fixed.
+    pub node: SyntaxNode,
+    // The items to remove from the imports.
+    pub items_to_remove: Vec<String>,
+}
+
 /// Attempts to fix a semantic diagnostic.
 ///
 /// This function is the entry point for fixing semantic diagnostics. It examines the
@@ -42,11 +53,124 @@ pub fn fix_semantic_diagnostic(db: &RootDatabase, diag: &SemanticDiagnostic) -> 
     match diag.kind {
         SemanticDiagnosticKind::UnusedVariable => Fixer.fix_unused_variable(db, diag),
         SemanticDiagnosticKind::PluginDiagnostic(ref plugin_diag) => Fixer.fix_plugin_diagnostic(db, diag, plugin_diag),
-        SemanticDiagnosticKind::UnusedImport(ref id) => Fixer.fix_unused_import(db, id),
+        // SemanticDiagnosticKind::UnusedImport(ref id) => Fixer.fix_unused_import(db, id),
         _ => {
             debug!("No fix available for diagnostic: {:?}", diag.kind);
             None
         }
+    }
+}
+
+pub fn collect_unused_imports(
+    db: &RootDatabase,
+    diags: &[Diagnostics<SemanticDiagnostic>],
+) -> HashMap<SyntaxNode, ImportFix> {
+    let mut fixes = HashMap::new();
+
+    for diag in diags
+        .iter()
+        .flat_map(|diags| diags.get_all())
+        .filter(|diag| matches!(diag.kind, SemanticDiagnosticKind::UnusedImport(_)))
+    {
+        if let SemanticDiagnosticKind::UnusedImport(id) = &diag.kind {
+            let unused_node = id.stable_ptr(db).lookup(db.upcast()).as_syntax_node();
+            let mut current_node = unused_node.clone();
+
+            while let Some(parent) = current_node.parent() {
+                match parent.kind(db) {
+                    SyntaxKind::UsePathMulti => {
+                        fixes
+                            .entry(parent.clone())
+                            .or_insert_with(|| ImportFix { node: parent.clone(), items_to_remove: vec![] })
+                            .items_to_remove
+                            .push(unused_node.clone().get_text_without_trivia(db));
+                        break;
+                    }
+                    SyntaxKind::ItemUse => {
+                        fixes.insert(parent.clone(), ImportFix { node: parent.clone(), items_to_remove: vec![] });
+                        break;
+                    }
+                    _ => current_node = parent,
+                }
+            }
+        }
+    }
+    fixes
+}
+
+pub fn apply_import_fixes(db: &RootDatabase, fixes: HashMap<SyntaxNode, ImportFix>) -> Vec<Fix> {
+    fixes
+        .into_iter()
+        .flat_map(|(_, import_fix)| {
+            let span = import_fix.node.span(db);
+
+            if import_fix.items_to_remove.is_empty() {
+                // Single import case: remove entire import
+                vec![Fix { span, suggestion: String::new() }]
+            } else {
+                // Multi-import case
+                handle_multi_import(db, &import_fix.node, &import_fix.items_to_remove)
+            }
+        })
+        .collect()
+}
+
+fn handle_multi_import(db: &RootDatabase, node: &SyntaxNode, items_to_remove: &[String]) -> Vec<Fix> {
+    let mut current_node = node.clone();
+    let mut all_descendants_removed = true;
+
+    // Check if all descendants are in items_to_remove. Descendants are of type UsePathLeaf
+    for child in current_node.descendants(db) {
+        if child.kind(db) == SyntaxKind::UsePathLeaf {
+            if !items_to_remove.contains(&child.get_text_without_trivia(db)) {
+                all_descendants_removed = false;
+                break;
+            }
+        }
+    }
+
+    if all_descendants_removed {
+        // Find the first "branching node" or ItemUse.
+        // It's a branching node if it's of type UsePathMulti.
+        while let Some(parent) = current_node.parent() {
+            if parent.kind(db) == SyntaxKind::UsePathMulti || parent.kind(db) == SyntaxKind::ItemUse {
+                current_node = parent.clone();
+                break;
+            }
+            current_node = parent;
+        }
+        // Remove the content of the child of this node
+        let span = current_node.span(db);
+        vec![Fix { span, suggestion: String::new() }]
+    } else {
+        // Remove specific items and handle the case of one remaining item
+        // Get the UsePathList descendant
+        let mut current_node = node.clone();
+        for descendant in current_node.descendants(db) {
+            if descendant.kind(db) == SyntaxKind::UsePathList {
+                current_node = descendant.clone();
+                break;
+            }
+            current_node = descendant;
+        }
+
+        // split by comma
+        let node_text = current_node.clone().get_text(db);
+        let mut items = node_text.split(',').map(|s| s.trim()).collect::<Vec<&str>>();
+
+        // Remove the items to remove from the items
+        for item in items_to_remove {
+            items.retain(|&x| x.trim() != item);
+        }
+
+        let text = if items.len() == 1 {
+            // Only one item left, remove the curly braces
+            items[0].to_string()
+        } else {
+            format!("{{ {} }}", items.join(", "))
+        };
+
+        vec![Fix { span: node.span(db), suggestion: text }]
     }
 }
 
@@ -196,54 +320,5 @@ impl Fixer {
             node.get_text(db).chars().take_while(|c| c.is_whitespace()).collect::<String>(),
             expr.as_syntax_node().get_text_without_trivia(db),
         )
-    }
-
-    /// Attempts to fix an unused import by removing it.
-    ///
-    /// This function handles both single imports and imports within a use tree.
-    /// For multi-import paths, it currently does not provide a fix.
-    ///
-    /// # Arguments
-    ///
-    /// * `db` - A reference to the RootDatabase
-    /// * `diag` - A reference to the SemanticDiagnostic
-    /// * `id` - A reference to the UseId of the unused import
-    ///
-    /// # Returns
-    ///
-    /// An `Option<(SyntaxNode, String)>` containing the node to be removed and an empty string
-    /// (indicating removal). Returns `None` for multi-import paths.
-    pub fn fix_unused_import(&self, db: &RootDatabase, id: &UseId) -> Option<(SyntaxNode, String)> {
-        let mut current_node = id.stable_ptr(db).lookup(db.upcast()).as_syntax_node();
-        let mut path_to_remove = vec![current_node.clone()];
-        let mut remove_entire_statement = true;
-
-        while let Some(parent) = current_node.parent() {
-            match parent.kind(db) {
-                SyntaxKind::UsePathSingle => {
-                    path_to_remove.push(parent.clone());
-                    current_node = parent;
-                }
-                SyntaxKind::UsePathMulti => {
-                    path_to_remove.push(parent.clone());
-                    remove_entire_statement = false;
-                    break;
-                }
-                SyntaxKind::ItemUse => {
-                    if remove_entire_statement {
-                        path_to_remove.push(parent.clone());
-                    }
-                    break;
-                }
-                _ => current_node = parent,
-            }
-        }
-
-        if remove_entire_statement {
-            Some((path_to_remove.last().unwrap().clone(), String::new()))
-        } else {
-            warn!("Autofix not supported for multi-import paths: {:?}", id);
-            None
-        }
     }
 }

--- a/crates/cairo-lint-core/src/fix.rs
+++ b/crates/cairo-lint-core/src/fix.rs
@@ -18,20 +18,15 @@ use crate::lints::bool_comparison::generate_fixed_text_for_comparison;
 use crate::lints::single_match::is_expr_unit;
 use crate::plugin::{diagnostic_kind_from_message, CairoLintKind};
 
+mod import_fixes;
+pub use import_fixes::{apply_import_fixes, collect_unused_imports, ImportFix};
+
 /// Represents a fix for a diagnostic, containing the span of code to be replaced
 /// and the suggested replacement.
 #[derive(Debug, Clone)]
 pub struct Fix {
     pub span: TextSpan,
     pub suggestion: String,
-}
-
-#[derive(Debug, Clone)]
-pub struct ImportFix {
-    // The node that contains the imports to be fixed.
-    pub node: SyntaxNode,
-    // The items to remove from the imports.
-    pub items_to_remove: Vec<String>,
 }
 
 /// Attempts to fix a semantic diagnostic.
@@ -58,119 +53,6 @@ pub fn fix_semantic_diagnostic(db: &RootDatabase, diag: &SemanticDiagnostic) -> 
             debug!("No fix available for diagnostic: {:?}", diag.kind);
             None
         }
-    }
-}
-
-pub fn collect_unused_imports(
-    db: &RootDatabase,
-    diags: &[Diagnostics<SemanticDiagnostic>],
-) -> HashMap<SyntaxNode, ImportFix> {
-    let mut fixes = HashMap::new();
-
-    for diag in diags
-        .iter()
-        .flat_map(|diags| diags.get_all())
-        .filter(|diag| matches!(diag.kind, SemanticDiagnosticKind::UnusedImport(_)))
-    {
-        if let SemanticDiagnosticKind::UnusedImport(id) = &diag.kind {
-            let unused_node = id.stable_ptr(db).lookup(db.upcast()).as_syntax_node();
-            let mut current_node = unused_node.clone();
-
-            while let Some(parent) = current_node.parent() {
-                match parent.kind(db) {
-                    SyntaxKind::UsePathMulti => {
-                        fixes
-                            .entry(parent.clone())
-                            .or_insert_with(|| ImportFix { node: parent.clone(), items_to_remove: vec![] })
-                            .items_to_remove
-                            .push(unused_node.clone().get_text_without_trivia(db));
-                        break;
-                    }
-                    SyntaxKind::ItemUse => {
-                        fixes.insert(parent.clone(), ImportFix { node: parent.clone(), items_to_remove: vec![] });
-                        break;
-                    }
-                    _ => current_node = parent,
-                }
-            }
-        }
-    }
-    fixes
-}
-
-pub fn apply_import_fixes(db: &RootDatabase, fixes: HashMap<SyntaxNode, ImportFix>) -> Vec<Fix> {
-    fixes
-        .into_iter()
-        .flat_map(|(_, import_fix)| {
-            let span = import_fix.node.span(db);
-
-            if import_fix.items_to_remove.is_empty() {
-                // Single import case: remove entire import
-                vec![Fix { span, suggestion: String::new() }]
-            } else {
-                // Multi-import case
-                handle_multi_import(db, &import_fix.node, &import_fix.items_to_remove)
-            }
-        })
-        .collect()
-}
-
-fn handle_multi_import(db: &RootDatabase, node: &SyntaxNode, items_to_remove: &[String]) -> Vec<Fix> {
-    let mut current_node = node.clone();
-    let mut all_descendants_removed = true;
-
-    // Check if all descendants are in items_to_remove. Descendants are of type UsePathLeaf
-    for child in current_node.descendants(db) {
-        if child.kind(db) == SyntaxKind::UsePathLeaf {
-            if !items_to_remove.contains(&child.get_text_without_trivia(db)) {
-                all_descendants_removed = false;
-                break;
-            }
-        }
-    }
-
-    if all_descendants_removed {
-        // Find the first "branching node" or ItemUse.
-        // It's a branching node if it's of type UsePathMulti.
-        while let Some(parent) = current_node.parent() {
-            if parent.kind(db) == SyntaxKind::UsePathMulti || parent.kind(db) == SyntaxKind::ItemUse {
-                current_node = parent.clone();
-                break;
-            }
-            current_node = parent;
-        }
-        // Remove the content of the child of this node
-        let span = current_node.span(db);
-        vec![Fix { span, suggestion: String::new() }]
-    } else {
-        // Remove specific items and handle the case of one remaining item
-        // Get the UsePathList descendant
-        let mut current_node = node.clone();
-        for descendant in current_node.descendants(db) {
-            if descendant.kind(db) == SyntaxKind::UsePathList {
-                current_node = descendant.clone();
-                break;
-            }
-            current_node = descendant;
-        }
-
-        // split by comma
-        let node_text = current_node.clone().get_text(db);
-        let mut items = node_text.split(',').map(|s| s.trim()).collect::<Vec<&str>>();
-
-        // Remove the items to remove from the items
-        for item in items_to_remove {
-            items.retain(|&x| x.trim() != item);
-        }
-
-        let text = if items.len() == 1 {
-            // Only one item left, remove the curly braces
-            items[0].to_string()
-        } else {
-            format!("{{ {} }}", items.join(", "))
-        };
-
-        vec![Fix { span: node.span(db), suggestion: text }]
     }
 }
 

--- a/crates/cairo-lint-core/src/fix.rs
+++ b/crates/cairo-lint-core/src/fix.rs
@@ -43,7 +43,10 @@ pub fn fix_semantic_diagnostic(db: &RootDatabase, diag: &SemanticDiagnostic) -> 
     match diag.kind {
         SemanticDiagnosticKind::UnusedVariable => Fixer.fix_unused_variable(db, diag),
         SemanticDiagnosticKind::PluginDiagnostic(ref plugin_diag) => Fixer.fix_plugin_diagnostic(db, diag, plugin_diag),
-        // SemanticDiagnosticKind::UnusedImport(ref id) => Fixer.fix_unused_import(db, id),
+        SemanticDiagnosticKind::UnusedImport(_) => {
+            debug!("Unused imports should be handled in preemptively");
+            None
+        }
         _ => {
             debug!("No fix available for diagnostic: {:?}", diag.kind);
             None

--- a/crates/cairo-lint-core/src/fix.rs
+++ b/crates/cairo-lint-core/src/fix.rs
@@ -1,18 +1,13 @@
-use std::collections::HashMap;
-
 use cairo_lang_compiler::db::RootDatabase;
-use cairo_lang_defs::ids::UseId;
 use cairo_lang_defs::plugin::PluginDiagnostic;
-use cairo_lang_diagnostics::Diagnostics;
 use cairo_lang_filesystem::span::TextSpan;
 use cairo_lang_semantic::diagnostic::SemanticDiagnosticKind;
 use cairo_lang_semantic::SemanticDiagnostic;
 use cairo_lang_syntax::node::ast::{Expr, ExprBinary, ExprMatch, Pattern};
 use cairo_lang_syntax::node::db::SyntaxGroup;
-use cairo_lang_syntax::node::kind::SyntaxKind;
-use cairo_lang_syntax::node::{SyntaxNode, TypedStablePtr, TypedSyntaxNode};
+use cairo_lang_syntax::node::{SyntaxNode, TypedSyntaxNode};
 use cairo_lang_utils::Upcast;
-use log::{debug, warn};
+use log::debug;
 
 use crate::lints::bool_comparison::generate_fixed_text_for_comparison;
 use crate::lints::single_match::is_expr_unit;

--- a/crates/cairo-lint-core/src/fix/import_fixes.rs
+++ b/crates/cairo-lint-core/src/fix/import_fixes.rs
@@ -1,0 +1,150 @@
+use std::collections::HashMap;
+
+use cairo_lang_compiler::db::RootDatabase;
+use cairo_lang_defs::ids::UseId;
+use cairo_lang_diagnostics::{DiagnosticEntry, Diagnostics};
+use cairo_lang_filesystem::ids::FileId;
+use cairo_lang_semantic::diagnostic::SemanticDiagnosticKind;
+use cairo_lang_semantic::SemanticDiagnostic;
+use cairo_lang_syntax::node::db::SyntaxGroup;
+use cairo_lang_syntax::node::kind::SyntaxKind;
+use cairo_lang_syntax::node::{SyntaxNode, TypedStablePtr, TypedSyntaxNode};
+use cairo_lang_utils::Upcast;
+
+#[derive(Debug, Clone)]
+pub struct ImportFix {
+    // The node that contains the imports to be fixed.
+    pub node: SyntaxNode,
+    // The items to remove from the imports.
+    pub items_to_remove: Vec<String>,
+}
+
+impl ImportFix {
+    pub fn new(node: SyntaxNode) -> Self {
+        ImportFix { node, items_to_remove: vec![] }
+    }
+}
+
+use crate::fix::Fix;
+
+pub fn collect_unused_imports(
+    db: &RootDatabase,
+    diags: &Vec<SemanticDiagnostic>,
+) -> HashMap<FileId, HashMap<SyntaxNode, ImportFix>> {
+    let mut file_fixes = HashMap::new();
+
+    for diag in diags {
+        if let SemanticDiagnosticKind::UnusedImport(id) = &diag.kind {
+            let file_id = diag.location(db.upcast()).file_id;
+
+            let mut local_fixes = file_fixes.entry(file_id).or_insert_with(HashMap::new);
+            process_unused_import(db, id, &mut local_fixes);
+        }
+    }
+
+    file_fixes
+}
+
+fn process_unused_import(db: &RootDatabase, id: &UseId, fixes: &mut HashMap<SyntaxNode, ImportFix>) {
+    let unused_node = id.stable_ptr(db).lookup(db.upcast()).as_syntax_node();
+    let mut current_node = unused_node.clone();
+
+    while let Some(parent) = current_node.parent() {
+        match parent.kind(db) {
+            SyntaxKind::UsePathMulti => {
+                fixes
+                    .entry(parent.clone())
+                    .or_insert_with(|| ImportFix::new(parent.clone()))
+                    .items_to_remove
+                    .push(unused_node.get_text_without_trivia(db));
+                break;
+            }
+            SyntaxKind::ItemUse => {
+                fixes.insert(parent.clone(), ImportFix::new(parent.clone()));
+                break;
+            }
+            _ => current_node = parent,
+        }
+    }
+}
+
+pub fn apply_import_fixes(db: &RootDatabase, fixes: &HashMap<SyntaxNode, ImportFix>) -> Vec<Fix> {
+    fixes
+        .into_iter()
+        .flat_map(|(_, import_fix)| {
+            let span = import_fix.node.span(db);
+
+            if import_fix.items_to_remove.is_empty() {
+                // Single import case: remove entire import
+                vec![Fix { span, suggestion: String::new() }]
+            } else {
+                // Multi-import case
+                handle_multi_import(db, &import_fix.node, &import_fix.items_to_remove)
+            }
+        })
+        .collect()
+}
+
+fn handle_multi_import(db: &RootDatabase, node: &SyntaxNode, items_to_remove: &[String]) -> Vec<Fix> {
+    if all_descendants_removed(db, node, items_to_remove) {
+        remove_entire_import(db, node)
+    } else {
+        remove_specific_items(db, node, items_to_remove)
+    }
+}
+
+fn all_descendants_removed(db: &RootDatabase, node: &SyntaxNode, items_to_remove: &[String]) -> bool {
+    node.descendants(db)
+        .filter(|child| child.kind(db) == SyntaxKind::UsePathLeaf)
+        .all(|child| items_to_remove.contains(&child.get_text_without_trivia(db)))
+}
+
+fn remove_entire_import(db: &RootDatabase, node: &SyntaxNode) -> Vec<Fix> {
+    let mut current_node = node.clone();
+    while let Some(parent) = current_node.parent() {
+        // Go up until we find a UsePathList on the path - then, we can remove the current node from that
+        // list.
+        if matches!(parent.kind(db), SyntaxKind::UsePathList) {
+            // To remove the current node from the UsePathList, we need to:
+            // 1. Get the text of the current node, which becomes "to remove"
+            // 2. Rewrite the UsePathList with the current node text removed.
+            let items_to_remove = vec![current_node.get_text_without_trivia(db)];
+            let parent = parent.parent().unwrap().clone();
+            let fix = handle_multi_import(db, &parent, &items_to_remove);
+            return fix;
+        }
+        if matches!(parent.kind(db), SyntaxKind::ItemUse) {
+            current_node = parent.clone();
+            break;
+        }
+        current_node = parent;
+    }
+    vec![Fix { span: current_node.span(db), suggestion: String::new() }]
+}
+
+fn remove_specific_items(db: &RootDatabase, node: &SyntaxNode, items_to_remove: &[String]) -> Vec<Fix> {
+    let use_path_list = find_use_path_list(db, node);
+    let node_text = use_path_list.get_text(db);
+    let children = db.get_children(use_path_list.clone());
+    let children_text = children.iter().map(|child| child.get_text(db)).collect::<Vec<_>>().join(", ");
+    let children: Vec<SyntaxNode> = children
+        .into_iter()
+        .filter(|child| {
+            let text = child.get_text(db).trim().replace('\n', "");
+            !text.is_empty() && !text.eq(",")
+        })
+        .cloned()
+        .collect();
+    let mut items: Vec<_> = children.iter().map(|child| child.get_text(db).trim().to_string()).collect();
+    items.retain(|item| !items_to_remove.contains(&item.to_string()));
+
+    let text = if items.len() == 1 { items[0].to_string() } else { format!("{{ {} }}", items.join(", ")) };
+
+    vec![Fix { span: node.span(db), suggestion: text }]
+}
+
+fn find_use_path_list(db: &RootDatabase, node: &SyntaxNode) -> SyntaxNode {
+    node.descendants(db)
+        .find(|descendant| descendant.kind(db) == SyntaxKind::UsePathList)
+        .unwrap_or_else(|| node.clone())
+}

--- a/crates/cairo-lint-core/src/fix/import_fixes.rs
+++ b/crates/cairo-lint-core/src/fix/import_fixes.rs
@@ -180,17 +180,17 @@ fn remove_entire_import(db: &RootDatabase, node: &SyntaxNode) -> Vec<Fix> {
     while let Some(parent) = current_node.parent() {
         // Go up until we find a UsePathList on the path - then, we can remove the current node from that
         // list.
-        if matches!(parent.kind(db), SyntaxKind::UsePathList) {
+        if parent.kind(db) == SyntaxKind::UsePathList {
             // To remove the current node from the UsePathList, we need to:
             // 1. Get the text of the current node, which becomes "to remove"
             // 2. Rewrite the UsePathList with the current node text removed.
             let items_to_remove = vec![current_node.get_text_without_trivia(db)];
-            let parent = parent.parent().unwrap().clone();
-            let fix = handle_multi_import(db, &parent, &items_to_remove);
-            return fix;
+            if let Some(grandparent) = parent.parent() {
+                return handle_multi_import(db, &grandparent, &items_to_remove);
+            }
         }
-        if matches!(parent.kind(db), SyntaxKind::ItemUse) {
-            current_node = parent.clone();
+        if parent.kind(db) == SyntaxKind::ItemUse {
+            current_node = parent;
             break;
         }
         current_node = parent;

--- a/crates/cairo-lint-core/src/fix/import_fixes.rs
+++ b/crates/cairo-lint-core/src/fix/import_fixes.rs
@@ -1,3 +1,15 @@
+//! # Import Fixes for Cairo Lint
+//!
+//! This module provides functionality to detect and fix unused imports in Cairo code.
+//! The process involves three main steps:
+//!
+//! 1. Collecting unused imports: Analyze semantic diagnostics to identify unused imports.
+//! 2. Creating import fixes: Generate `ImportFix` structures for each unused import.
+//! 3. Applying fixes: Remove or modify the imports based on the collected fixes.
+//!
+//! The module handles both single imports and multi-imports, ensuring that only unused
+//! items are removed while preserving the structure of the import statements.
+
 use std::collections::HashMap;
 
 use cairo_lang_compiler::db::RootDatabase;
@@ -11,15 +23,17 @@ use cairo_lang_syntax::node::kind::SyntaxKind;
 use cairo_lang_syntax::node::{SyntaxNode, TypedStablePtr, TypedSyntaxNode};
 use cairo_lang_utils::Upcast;
 
+/// Represents a fix for unused imports in a specific syntax node.
 #[derive(Debug, Clone)]
 pub struct ImportFix {
-    // The node that contains the imports to be fixed.
+    /// The node that contains the imports to be fixed.
     pub node: SyntaxNode,
-    // The items to remove from the imports.
+    /// The items to remove from the imports.
     pub items_to_remove: Vec<String>,
 }
 
 impl ImportFix {
+    /// Creates a new `ImportFix` for the given syntax node.
     pub fn new(node: SyntaxNode) -> Self {
         ImportFix { node, items_to_remove: vec![] }
     }
@@ -27,6 +41,16 @@ impl ImportFix {
 
 use crate::fix::Fix;
 
+/// Collects unused imports from semantic diagnostics.
+///
+/// # Arguments
+///
+/// * `db` - The root database containing the project information.
+/// * `diags` - A vector of semantic diagnostics.
+///
+/// # Returns
+///
+/// A HashMap where keys are FileIds and values are HashMaps of SyntaxNodes to ImportFixes.
 pub fn collect_unused_imports(
     db: &RootDatabase,
     diags: &Vec<SemanticDiagnostic>,
@@ -45,6 +69,13 @@ pub fn collect_unused_imports(
     file_fixes
 }
 
+/// Processes an unused import and updates the fixes HashMap.
+///
+/// # Arguments
+///
+/// * `db` - The root database containing the project information.
+/// * `id` - The UseId of the unused import.
+/// * `fixes` - A mutable reference to the HashMap of fixes.
 fn process_unused_import(db: &RootDatabase, id: &UseId, fixes: &mut HashMap<SyntaxNode, ImportFix>) {
     let unused_node = id.stable_ptr(db).lookup(db.upcast()).as_syntax_node();
     let mut current_node = unused_node.clone();
@@ -68,6 +99,16 @@ fn process_unused_import(db: &RootDatabase, id: &UseId, fixes: &mut HashMap<Synt
     }
 }
 
+/// Applies the collected import fixes to generate a list of Fix objects.
+///
+/// # Arguments
+///
+/// * `db` - The root database containing the project information.
+/// * `fixes` - A HashMap of SyntaxNodes to ImportFixes.
+///
+/// # Returns
+///
+/// A vector of Fix objects representing the applied fixes.
 pub fn apply_import_fixes(db: &RootDatabase, fixes: &HashMap<SyntaxNode, ImportFix>) -> Vec<Fix> {
     fixes
         .iter()
@@ -85,6 +126,17 @@ pub fn apply_import_fixes(db: &RootDatabase, fixes: &HashMap<SyntaxNode, ImportF
         .collect()
 }
 
+/// Handles multi-import cases, deciding whether to remove the entire import or specific items.
+///
+/// # Arguments
+///
+/// * `db` - The root database containing the project information.
+/// * `node` - The syntax node of the import.
+/// * `items_to_remove` - A slice of strings representing the items to be removed.
+///
+/// # Returns
+///
+/// A vector of Fix objects for the multi-import case.
 fn handle_multi_import(db: &RootDatabase, node: &SyntaxNode, items_to_remove: &[String]) -> Vec<Fix> {
     if all_descendants_removed(db, node, items_to_remove) {
         remove_entire_import(db, node)
@@ -93,12 +145,36 @@ fn handle_multi_import(db: &RootDatabase, node: &SyntaxNode, items_to_remove: &[
     }
 }
 
+/// Checks if all descendants of a node are to be removed.
+///
+/// # Arguments
+///
+/// * `db` - The root database containing the project information.
+/// * `node` - The syntax node to check.
+/// * `items_to_remove` - A slice of strings representing the items to be removed.
+///
+/// # Returns
+///
+/// A boolean indicating whether all descendants should be removed.
 fn all_descendants_removed(db: &RootDatabase, node: &SyntaxNode, items_to_remove: &[String]) -> bool {
     node.descendants(db)
         .filter(|child| child.kind(db) == SyntaxKind::UsePathLeaf)
         .all(|child| items_to_remove.contains(&child.get_text_without_trivia(db)))
 }
 
+/// Removes an entire import statement.
+///
+/// We traverse the parents until we either find a UsePathList on the path - then, we can remove the
+/// current node from that list - or we find an ItemUse, in which case we remove the entire import
+/// line.
+///
+/// # Arguments
+/// * `db` - The root database containing the project information.
+/// * `node` - The syntax node of the import to remove.
+///
+/// # Returns
+///
+/// A vector of Fix objects for removing the entire import.
 fn remove_entire_import(db: &RootDatabase, node: &SyntaxNode) -> Vec<Fix> {
     let mut current_node = node.clone();
     while let Some(parent) = current_node.parent() {
@@ -122,6 +198,17 @@ fn remove_entire_import(db: &RootDatabase, node: &SyntaxNode) -> Vec<Fix> {
     vec![Fix { span: current_node.span(db), suggestion: String::new() }]
 }
 
+/// Removes specific items from a multi-import statement.
+///
+/// # Arguments
+///
+/// * `db` - The root database containing the project information.
+/// * `node` - The syntax node of the import.
+/// * `items_to_remove` - A slice of strings representing the items to be removed.
+///
+/// # Returns
+///
+/// A vector of Fix objects for removing specific items from the import.
 fn remove_specific_items(db: &RootDatabase, node: &SyntaxNode, items_to_remove: &[String]) -> Vec<Fix> {
     let use_path_list = find_use_path_list(db, node);
     let children = db.get_children(use_path_list.clone());
@@ -141,6 +228,16 @@ fn remove_specific_items(db: &RootDatabase, node: &SyntaxNode, items_to_remove: 
     vec![Fix { span: node.span(db), suggestion: text }]
 }
 
+/// Finds the UsePathList node within a given syntax node.
+///
+/// # Arguments
+///
+/// * `db` - The root database containing the project information.
+/// * `node` - The syntax node to search within.
+///
+/// # Returns
+///
+/// The UsePathList syntax node, or the original node if not found.
 fn find_use_path_list(db: &RootDatabase, node: &SyntaxNode) -> SyntaxNode {
     node.descendants(db)
         .find(|descendant| descendant.kind(db) == SyntaxKind::UsePathList)

--- a/crates/cairo-lint-core/tests/test_files/unused_imports/unused_imports
+++ b/crates/cairo-lint-core/tests/test_files/unused_imports/unused_imports
@@ -7,7 +7,7 @@ use core::{
 };
 
 fn main() {
-    let _ = Option::Some(5);
+    let _ = Option::<u128>::Some(5);
 }
 
 //! > diagnostics
@@ -23,18 +23,12 @@ warning: Unused import: `test::u128_byte_reverse`
 2 |     integer::{u128_safe_divmod, u128_byte_reverse},
   |                                 -----------------
   |
-error: Cannot infer trait core::integer::NumericLiteral::<?0>. First generic argument must be known.
-  --> lib.cairo:12:26
-   |
-12 |     let _ = Option::Some(5);
-   |                          ^
-   |
 
 //! > fixed
 use core::option::Option;
 
 fn main() {
-    let _ = Option::Some(5);
+    let _ = Option::<u128>::Some(5);
 }
 
 //! > ==========================================================================
@@ -54,12 +48,6 @@ warning: Unused import: `test::u128_safe_divmod`
 0 | use core::integer::{u128_safe_divmod, u128_byte_reverse};
  |                     ----------------
  |
-error: Type mismatch: `core::integer::u128` and `core::felt252`.
- --> lib.cairo:4:23
-  |
-4 |     u128_byte_reverse(10_u128);
-  |                       ^^^^^^^
-  |
 
 //! > fixed
 use core::integer::u128_byte_reverse;
@@ -77,8 +65,8 @@ use core::array::ArrayTrait;
 use core::box::BoxTrait;
 
 fn main() {
-    let _ = Option::Some(5);
-    let _res = BoxTrait::new(5);
+    let _ = Option::<u128>::Some(5);
+    let _res = BoxTrait::<u128>::new(5);
 }
 
 //! > diagnostics
@@ -88,20 +76,14 @@ warning: Unused import: `test::ArrayTrait`
 2 | use core::array::ArrayTrait;
   |                  ----------
   |
-error: Cannot infer trait core::integer::NumericLiteral::<?0>. First generic argument must be known.
-  --> lib.cairo:12:30
-   |
-12 |     let _res = BoxTrait::new(5);
-   |                              ^
-   |
 
 //! > fixed
 use core::option::Option;
 use core::box::BoxTrait;
 
 fn main() {
-    let _ = Option::Some(5);
-    let _res = BoxTrait::new(5);
+    let _ = Option::<u128>::Some(5);
+    let _res = BoxTrait::<u128>::new(5);
 }
 
 //! > ==========================================================================

--- a/crates/cairo-lint-core/tests/test_files/unused_imports/unused_imports
+++ b/crates/cairo-lint-core/tests/test_files/unused_imports/unused_imports
@@ -1,28 +1,41 @@
-//! > multiple unused imports
+//! > mix of multi and leaf imports in a single statement
 
 //! > cairo_code
-use core::integer::{u128_safe_divmod, u128_byte_reverse};
+use core::{
+    integer::{u128_safe_divmod, u128_byte_reverse},
+    option::Option,
+};
+
 fn main() {
+    let _ = Option::Some(5);
 }
 
 //! > diagnostics
 warning: Unused import: `test::u128_safe_divmod`
---> lib.cairo:0:21
- |
-0 | use core::integer::{u128_safe_divmod, u128_byte_reverse};
- |                     ----------------
- |
+ --> lib.cairo:2:15
+  |
+2 |     integer::{u128_safe_divmod, u128_byte_reverse},
+  |               ----------------
+  |
 warning: Unused import: `test::u128_byte_reverse`
---> lib.cairo:0:39
- |
-0 | use core::integer::{u128_safe_divmod, u128_byte_reverse};
- |                                       -----------------
- |
+ --> lib.cairo:2:33
+  |
+2 |     integer::{u128_safe_divmod, u128_byte_reverse},
+  |                                 -----------------
+  |
+error: Cannot infer trait core::integer::NumericLiteral::<?0>. First generic argument must be known.
+  --> lib.cairo:12:26
+   |
+12 |     let _ = Option::Some(5);
+   |                          ^
+   |
 
 //! > fixed
-fn main() {
-}
+use core::option::Option;
 
+fn main() {
+    let _ = Option::Some(5);
+}
 
 //! > ==========================================================================
 
@@ -54,10 +67,71 @@ fn main() {
     u128_byte_reverse(10_u128);
 }
 
+//! > ==========================================================================
 
+//! > multiple import statements lines with some used and some unused
+
+//! > cairo_code
+use core::option::Option;
+use core::array::ArrayTrait;
+use core::box::BoxTrait;
+
+fn main() {
+    let _ = Option::Some(5);
+    let _res = BoxTrait::new(5);
+}
+
+//! > diagnostics
+warning: Unused import: `test::ArrayTrait`
+ --> lib.cairo:2:18
+  |
+2 | use core::array::ArrayTrait;
+  |                  ----------
+  |
+error: Cannot infer trait core::integer::NumericLiteral::<?0>. First generic argument must be known.
+  --> lib.cairo:12:30
+   |
+12 |     let _res = BoxTrait::new(5);
+   |                              ^
+   |
+
+//! > fixed
+use core::option::Option;
+use core::box::BoxTrait;
+
+fn main() {
+    let _ = Option::Some(5);
+    let _res = BoxTrait::new(5);
+}
 
 //! > ==========================================================================
 
+//! > multiple unused imports
+
+//! > cairo_code
+use core::integer::{u128_safe_divmod, u128_byte_reverse};
+fn main() {
+}
+
+//! > diagnostics
+warning: Unused import: `test::u128_safe_divmod`
+--> lib.cairo:0:21
+ |
+0 | use core::integer::{u128_safe_divmod, u128_byte_reverse};
+ |                     ----------------
+ |
+warning: Unused import: `test::u128_byte_reverse`
+--> lib.cairo:0:39
+ |
+0 | use core::integer::{u128_safe_divmod, u128_byte_reverse};
+ |                                       -----------------
+ |
+
+//! > fixed
+fn main() {
+}
+
+//! > ==========================================================================
 
 //! > single unused import
 

--- a/crates/cairo-lint-core/tests/test_files/unused_imports/unused_imports
+++ b/crates/cairo-lint-core/tests/test_files/unused_imports/unused_imports
@@ -20,11 +20,44 @@ warning: Unused import: `test::u128_byte_reverse`
  |
 
 //! > fixed
-use core::integer::{u128_safe_divmod, u128_byte_reverse};
 fn main() {
 }
 
+
 //! > ==========================================================================
+
+//! > multi with one used and one unused
+
+//! > cairo_code
+use core::integer::{u128_safe_divmod, u128_byte_reverse};
+fn main() {
+    u128_byte_reverse(10_u128);
+}
+
+//! > diagnostics
+warning: Unused import: `test::u128_safe_divmod`
+--> lib.cairo:0:21
+ |
+0 | use core::integer::{u128_safe_divmod, u128_byte_reverse};
+ |                     ----------------
+ |
+error: Type mismatch: `core::integer::u128` and `core::felt252`.
+ --> lib.cairo:4:23
+  |
+4 |     u128_byte_reverse(10_u128);
+  |                       ^^^^^^^
+  |
+
+//! > fixed
+use core::integer::u128_byte_reverse;
+fn main() {
+    u128_byte_reverse(10_u128);
+}
+
+
+
+//! > ==========================================================================
+
 
 //! > single unused import
 

--- a/crates/cairo-lint-core/tests/tests.rs
+++ b/crates/cairo-lint-core/tests/tests.rs
@@ -1,4 +1,3 @@
-use std::cmp::Reverse;
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::{LazyLock, Mutex};

--- a/crates/cairo-lint-core/tests/tests.rs
+++ b/crates/cairo-lint-core/tests/tests.rs
@@ -5,6 +5,7 @@ use std::sync::{LazyLock, Mutex};
 
 use annotate_snippets::Renderer;
 use cairo_lang_compiler::db::RootDatabase;
+use cairo_lang_filesystem::ids::FileId;
 use cairo_lang_semantic::diagnostic::SemanticDiagnosticKind;
 use cairo_lang_semantic::inline_macros::get_default_plugin_suite;
 use cairo_lang_semantic::test_utils::setup_test_crate_ex;
@@ -57,7 +58,9 @@ test_file!(
     "multiple unused imports",
     "unused import aliased",
     "unused import trait",
-    "multi with one used and one unused"
+    "multi with one used and one unused",
+    "mix of multi and leaf imports in a single statement",
+    "multiple import statements lines with some used and some unused"
 );
 
 test_file!(

--- a/crates/cairo-lint-core/tests/tests.rs
+++ b/crates/cairo-lint-core/tests/tests.rs
@@ -1,17 +1,20 @@
 use std::cmp::Reverse;
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::{LazyLock, Mutex};
 
 use annotate_snippets::Renderer;
 use cairo_lang_compiler::db::RootDatabase;
+use cairo_lang_semantic::diagnostic::SemanticDiagnosticKind;
 use cairo_lang_semantic::inline_macros::get_default_plugin_suite;
 use cairo_lang_semantic::test_utils::setup_test_crate_ex;
+use cairo_lang_syntax::node::SyntaxNode;
 use cairo_lang_test_plugin::test_plugin_suite;
 use cairo_lang_test_utils::parse_test_file::{dump_to_test_file, parse_test_file, Test};
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use cairo_lang_utils::Upcast;
 use cairo_lint_core::diagnostics::format_diagnostic;
-use cairo_lint_core::fix::{fix_semantic_diagnostic, Fix};
+use cairo_lint_core::fix::{apply_import_fixes, collect_unused_imports, fix_semantic_diagnostic, Fix, ImportFix};
 use cairo_lint_core::plugin::cairo_lint_plugin_suite;
 use cairo_lint_test_utils::{get_diags, test_file, Tests};
 use ctor::dtor;
@@ -53,7 +56,8 @@ test_file!(
     "single unused import",
     "multiple unused imports",
     "unused import aliased",
-    "unused import trait"
+    "unused import trait",
+    "multi with one used and one unused"
 );
 
 test_file!(

--- a/crates/cairo-lint-test-utils/src/lib.rs
+++ b/crates/cairo-lint-test-utils/src/lib.rs
@@ -72,8 +72,12 @@ macro_rules! test_file {
                 let semantic_diags: Vec<_> = diags.clone().into_iter().flat_map(|diag| diag.get_all()).collect();
                 let unused_imports: HashMap<FileId, HashMap<SyntaxNode, ImportFix>> =
                     collect_unused_imports(&db, &semantic_diags);
-                let current_file_id = unused_imports.keys().next().unwrap();
-                let mut fixes: Vec<Fix> = apply_import_fixes(&db, unused_imports.get(&current_file_id).unwrap());
+                let mut fixes = if unused_imports.keys().len() > 0 {
+                    let current_file_id = unused_imports.keys().next().unwrap();
+                    apply_import_fixes(&db, unused_imports.get(&current_file_id).unwrap())
+                } else {
+                    Vec::new()
+                };
 
                 // Handle other types of fixes
                 for diag in diags.iter().flat_map(|diags| diags.get_all()) {

--- a/crates/cairo-lint-test-utils/src/lib.rs
+++ b/crates/cairo-lint-test-utils/src/lib.rs
@@ -66,16 +66,22 @@ macro_rules! test_file {
                     .with_plugin_suite(cairo_lint_plugin_suite())
                     .build()
                     .unwrap();
-                let mut fixes = Vec::new();
 
                 let diags = get_diags(setup_test_crate_ex(db.upcast(), &file, Some(CRATE_CONFIG)), &mut db);
+                let unused_imports: HashMap<SyntaxNode, ImportFix> = collect_unused_imports(&db, &diags);
+                let mut fixes: Vec<Fix> = apply_import_fixes(&db, unused_imports);
+
+                // Handle other types of fixes
                 for diag in diags.iter().flat_map(|diags| diags.get_all()) {
-                    if let Some((fix_node, fix)) = fix_semantic_diagnostic(&db, &diag){
-                    let span = fix_node.span(db.upcast());
-                    fixes.push(Fix { span, suggestion: fix });
+                    if !matches!(diag.kind, SemanticDiagnosticKind::UnusedImport(_)) {
+                        if let Some((fix_node, fix)) = fix_semantic_diagnostic(&db, &diag) {
+                            let span = fix_node.span(db.upcast());
+                            fixes.push(Fix { span, suggestion: fix });
+                        }
                     }
                 }
-                fixes.sort_by_key(|v| Reverse(v.span.start));
+
+                fixes.sort_by_key(|v| std::cmp::Reverse(v.span.start));
                 if !test_name.contains("nested") {
                     for fix in fixes.iter() {
                         file.replace_range(fix.span.to_str_range(), &fix.suggestion);


### PR DESCRIPTION
Add lints and autofix for multiple unused imports.

Closes #18

e.g. 
```
use a::b::{c, d, e::f};
```

-> 

```
use a::b::c
```