### PR TITLE
feat: loop for while lint

### DIFF
--- a/crates/cairo-lint-core/src/fix.rs
+++ b/crates/cairo-lint-core/src/fix.rs
@@ -3,16 +3,16 @@ use cairo_lang_defs::plugin::PluginDiagnostic;
 use cairo_lang_filesystem::span::TextSpan;
 use cairo_lang_semantic::diagnostic::SemanticDiagnosticKind;
 use cairo_lang_semantic::SemanticDiagnostic;
-use cairo_lang_syntax::node::ast::{Expr, ExprMatch, Pattern};
+use cairo_lang_syntax::node::ast::{ Expr, ExprLoop, ExprMatch, Pattern, Statement };
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::kind::SyntaxKind;
-use cairo_lang_syntax::node::{SyntaxNode, TypedStablePtr, TypedSyntaxNode};
+use cairo_lang_syntax::node::{ SyntaxNode, TypedStablePtr, TypedSyntaxNode };
 use cairo_lang_utils::Upcast;
-use log::{debug, warn};
+use log::{ debug, warn };
 
 use crate::db::AnalysisDatabase;
 use crate::lints::single_match::is_expr_unit;
-use crate::plugin::{diagnostic_kind_from_message, CairoLintKind};
+use crate::plugin::{ diagnostic_kind_from_message, CairoLintKind };
 
 /// Represents a fix for a diagnostic, containing the span of code to be replaced
 /// and the suggested replacement.
@@ -37,10 +37,14 @@ pub struct Fix {
 /// An `Option<(SyntaxNode, String)>` where the `SyntaxNode` represents the node to be
 /// replaced, and the `String` is the suggested replacement. Returns `None` if no fix
 /// is available for the given diagnostic.
-pub fn fix_semantic_diagnostic(db: &AnalysisDatabase, diag: &SemanticDiagnostic) -> Option<(SyntaxNode, String)> {
+pub fn fix_semantic_diagnostic(
+    db: &AnalysisDatabase,
+    diag: &SemanticDiagnostic
+) -> Option<(SyntaxNode, String)> {
     match diag.kind {
         SemanticDiagnosticKind::UnusedVariable => Fixer.fix_unused_variable(db, diag),
-        SemanticDiagnosticKind::PluginDiagnostic(ref plugin_diag) => Fixer.fix_plugin_diagnostic(db, diag, plugin_diag),
+        SemanticDiagnosticKind::PluginDiagnostic(ref plugin_diag) =>
+            Fixer.fix_plugin_diagnostic(db, diag, plugin_diag),
         SemanticDiagnosticKind::UnusedImport(ref id) => Fixer.fix_unused_import(db, id),
         _ => {
             debug!("No fix available for diagnostic: {:?}", diag.kind);
@@ -66,7 +70,7 @@ impl Fixer {
     pub fn fix_unused_variable(
         &self,
         db: &AnalysisDatabase,
-        diag: &SemanticDiagnostic,
+        diag: &SemanticDiagnostic
     ) -> Option<(SyntaxNode, String)> {
         let node = diag.stable_location.syntax_node(db.upcast());
         let suggestion = format!("_{}", node.get_text(db.upcast()));
@@ -95,31 +99,36 @@ impl Fixer {
         let arms = match_expr.arms(db).elements(db);
         let first_arm = &arms[0];
         let second_arm = &arms[1];
-        let (pattern, first_expr) =
-            match (&first_arm.patterns(db).elements(db)[0], &second_arm.patterns(db).elements(db)[0]) {
-                (Pattern::Underscore(_), Pattern::Enum(pat)) => (pat.as_syntax_node(), second_arm),
-                (Pattern::Enum(pat), Pattern::Underscore(_)) => (pat.as_syntax_node(), first_arm),
-                (Pattern::Underscore(_), Pattern::Struct(pat)) => (pat.as_syntax_node(), second_arm),
-                (Pattern::Struct(pat), Pattern::Underscore(_)) => (pat.as_syntax_node(), first_arm),
-                (Pattern::Enum(pat1), Pattern::Enum(pat2)) => {
-                    if is_expr_unit(second_arm.expression(db), db) {
-                        (pat1.as_syntax_node(), first_arm)
-                    } else {
-                        (pat2.as_syntax_node(), second_arm)
-                    }
+        let (pattern, first_expr) = match
+            (&first_arm.patterns(db).elements(db)[0], &second_arm.patterns(db).elements(db)[0])
+        {
+            (Pattern::Underscore(_), Pattern::Enum(pat)) => (pat.as_syntax_node(), second_arm),
+            (Pattern::Enum(pat), Pattern::Underscore(_)) => (pat.as_syntax_node(), first_arm),
+            (Pattern::Underscore(_), Pattern::Struct(pat)) => (pat.as_syntax_node(), second_arm),
+            (Pattern::Struct(pat), Pattern::Underscore(_)) => (pat.as_syntax_node(), first_arm),
+            (Pattern::Enum(pat1), Pattern::Enum(pat2)) => {
+                if is_expr_unit(second_arm.expression(db), db) {
+                    (pat1.as_syntax_node(), first_arm)
+                } else {
+                    (pat2.as_syntax_node(), second_arm)
                 }
-                (_, _) => panic!("Incorrect diagnostic"),
-            };
+            }
+            (_, _) => panic!("Incorrect diagnostic"),
+        };
         let mut pattern_span = pattern.span(db);
         pattern_span.end = pattern.span_start_without_trivia(db);
-        let indent = node.get_text(db).chars().take_while(|c| c.is_whitespace()).collect::<String>();
+        let indent = node
+            .get_text(db)
+            .chars()
+            .take_while(|c| c.is_whitespace())
+            .collect::<String>();
         let trivia = pattern.clone().get_text_of_span(db, pattern_span).trim().to_string();
         let trivia = if trivia.is_empty() { trivia } else { format!("{indent}{trivia}\n") };
         format!(
             "{trivia}{indent}if let {} = {} {{ {} }}",
             pattern.get_text_without_trivia(db),
             match_expr.expr(db).as_syntax_node().get_text_without_trivia(db),
-            first_expr.expression(db).as_syntax_node().get_text_without_trivia(db),
+            first_expr.expression(db).as_syntax_node().get_text_without_trivia(db)
         )
     }
 
@@ -139,13 +148,14 @@ impl Fixer {
         &self,
         db: &AnalysisDatabase,
         semantic_diag: &SemanticDiagnostic,
-        plugin_diag: &PluginDiagnostic,
+        plugin_diag: &PluginDiagnostic
     ) -> Option<(SyntaxNode, String)> {
         let new_text = match diagnostic_kind_from_message(&plugin_diag.message) {
             CairoLintKind::DoubleParens => {
                 self.fix_double_parens(db.upcast(), plugin_diag.stable_ptr.lookup(db.upcast()))
             }
-            CairoLintKind::DestructMatch => self.fix_destruct_match(db, plugin_diag.stable_ptr.lookup(db.upcast())),
+            CairoLintKind::DestructMatch =>
+                self.fix_destruct_match(db, plugin_diag.stable_ptr.lookup(db.upcast())),
             _ => "".to_owned(),
         };
 
@@ -179,10 +189,57 @@ impl Fixer {
 
         format!(
             "{}{}",
-            node.get_text(db).chars().take_while(|c| c.is_whitespace()).collect::<String>(),
-            expr.as_syntax_node().get_text_without_trivia(db),
+            node
+                .get_text(db)
+                .chars()
+                .take_while(|c| c.is_whitespace())
+                .collect::<String>(),
+            expr.as_syntax_node().get_text_without_trivia(db)
         )
     }
+
+    pub fn fix_loop_break(&self, db: &dyn SyntaxGroup, node: SyntaxNode) -> String {
+        let loop_expr = ExprLoop::from_syntax_node(db, node.clone());
+        let mut condition_text = String::new();
+        let mut loop_body = String::new();
+        let mut found_break = false;
+    
+        for statement in loop_expr.body(db).statements(db).elements(db) {
+            if let Statement::Expr(ref expr_statement) = statement {
+                if let Expr::If(if_expr) = expr_statement.expr(db) {
+                    let condition = if_expr.condition(db);
+                    condition_text = condition.as_syntax_node().get_text_without_trivia(db).to_string();
+    
+                    // Revisamos el cuerpo del if para encontrar un break
+                    for inner_statement in if_expr.if_block(db).statements(db).elements(db) {
+                        if let Statement::Break(_) = inner_statement {
+                            found_break = true;
+                            break;
+                        }
+                    }
+    
+                    // Si encontramos el break, no incluimos el if block en el loop_body
+                    if found_break {
+                        continue;
+                    }
+                }
+            }
+    
+            // Agregar el resto del cuerpo del loop al nuevo cuerpo del while
+            loop_body.push_str(&statement.as_syntax_node().get_text_without_trivia(db));
+            loop_body.push('\n');
+        }
+    
+        if found_break {
+            // Construir la expresión while
+            format!("while {} {{\n{}\n}}", condition_text, loop_body.trim())
+        } else {
+            // Si no se encontró un break, devolvemos el código original
+            node.get_text(db).to_string()
+        }
+    }
+    
+    
 
     /// Attempts to fix an unused import by removing it.
     ///
@@ -199,7 +256,11 @@ impl Fixer {
     ///
     /// An `Option<(SyntaxNode, String)>` containing the node to be removed and an empty string
     /// (indicating removal). Returns `None` for multi-import paths.
-    pub fn fix_unused_import(&self, db: &AnalysisDatabase, id: &UseId) -> Option<(SyntaxNode, String)> {
+    pub fn fix_unused_import(
+        &self,
+        db: &AnalysisDatabase,
+        id: &UseId
+    ) -> Option<(SyntaxNode, String)> {
         let mut current_node = id.stable_ptr(db).lookup(db.upcast()).as_syntax_node();
         let mut path_to_remove = vec![current_node.clone()];
         let mut remove_entire_statement = true;
@@ -221,7 +282,9 @@ impl Fixer {
                     }
                     break;
                 }
-                _ => current_node = parent,
+                _ => {
+                    current_node = parent;
+                }
             }
         }
 

--- a/crates/cairo-lint-core/src/fix.rs
+++ b/crates/cairo-lint-core/src/fix.rs
@@ -146,10 +146,7 @@ impl Fixer {
                 self.fix_double_parens(db.upcast(), plugin_diag.stable_ptr.lookup(db.upcast()))
             }
             CairoLintKind::DestructMatch => self.fix_destruct_match(db, plugin_diag.stable_ptr.lookup(db.upcast())),
-            CairoLintKind::LoopForWhile => {
-                // Añade este caso
-                self.fix_loop_break(db.upcast(), plugin_diag.stable_ptr.lookup(db.upcast()))
-            }
+            CairoLintKind::LoopForWhile => self.fix_loop_break(db.upcast(), plugin_diag.stable_ptr.lookup(db.upcast())),
             _ => "".to_owned(),
         };
 
@@ -236,9 +233,7 @@ impl Fixer {
                 let condition = if_expr.condition(db);
                 condition_text = condition.as_syntax_node().get_text_without_trivia(db).to_string();
 
-                if condition_text != "true" {
-                    condition_text = Self::invert_condition(&condition_text);
-                }
+                condition_text = Self::invert_condition(&condition_text);
 
                 for statement in loop_expr.body(db).statements(db).elements(db).iter().skip(1) {
                     loop_body.push_str(&format!(
@@ -276,10 +271,6 @@ impl Fixer {
             condition.replace(">=", "<")
         } else if condition.contains("<=") {
             condition.replace("<=", ">")
-        } else if condition.contains('>') {
-            condition.replace('>', "<=")
-        } else if condition.contains('<') {
-            condition.replace('<', ">=")
         } else {
             format!("!({})", condition)
         }

--- a/crates/cairo-lint-core/src/fix.rs
+++ b/crates/cairo-lint-core/src/fix.rs
@@ -156,9 +156,12 @@ impl Fixer {
             }
             CairoLintKind::DestructMatch =>
                 self.fix_destruct_match(db, plugin_diag.stable_ptr.lookup(db.upcast())),
+            CairoLintKind::LoopForWhile => { // Añade este caso
+                self.fix_loop_break(db.upcast(), plugin_diag.stable_ptr.lookup(db.upcast()))
+            }
             _ => "".to_owned(),
         };
-
+    
         Some((semantic_diag.stable_location.syntax_node(db.upcast()), new_text))
     }
 
@@ -231,15 +234,13 @@ impl Fixer {
         }
     
         if found_break {
-            // Construir la expresión while
-            format!("while {} {{\n{}\n}}", condition_text, loop_body.trim())
+            // Construir la expresión while con la condición negada
+            format!("while !{} {{\n    {}}}", condition_text, loop_body.trim())
         } else {
             // Si no se encontró un break, devolvemos el código original
             node.get_text(db).to_string()
         }
     }
-    
-    
 
     /// Attempts to fix an unused import by removing it.
     ///

--- a/crates/cairo-lint-core/src/fix.rs
+++ b/crates/cairo-lint-core/src/fix.rs
@@ -3,16 +3,16 @@ use cairo_lang_defs::plugin::PluginDiagnostic;
 use cairo_lang_filesystem::span::TextSpan;
 use cairo_lang_semantic::diagnostic::SemanticDiagnosticKind;
 use cairo_lang_semantic::SemanticDiagnostic;
-use cairo_lang_syntax::node::ast::{ Expr, ExprLoop, ExprMatch, Pattern, Statement };
+use cairo_lang_syntax::node::ast::{Expr, ExprLoop, ExprMatch, Pattern, Statement};
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::kind::SyntaxKind;
-use cairo_lang_syntax::node::{ SyntaxNode, TypedStablePtr, TypedSyntaxNode };
+use cairo_lang_syntax::node::{SyntaxNode, TypedStablePtr, TypedSyntaxNode};
 use cairo_lang_utils::Upcast;
-use log::{ debug, warn };
+use log::{debug, warn};
 
 use crate::db::AnalysisDatabase;
 use crate::lints::single_match::is_expr_unit;
-use crate::plugin::{ diagnostic_kind_from_message, CairoLintKind };
+use crate::plugin::{diagnostic_kind_from_message, CairoLintKind};
 
 /// Represents a fix for a diagnostic, containing the span of code to be replaced
 /// and the suggested replacement.
@@ -37,14 +37,10 @@ pub struct Fix {
 /// An `Option<(SyntaxNode, String)>` where the `SyntaxNode` represents the node to be
 /// replaced, and the `String` is the suggested replacement. Returns `None` if no fix
 /// is available for the given diagnostic.
-pub fn fix_semantic_diagnostic(
-    db: &AnalysisDatabase,
-    diag: &SemanticDiagnostic
-) -> Option<(SyntaxNode, String)> {
+pub fn fix_semantic_diagnostic(db: &AnalysisDatabase, diag: &SemanticDiagnostic) -> Option<(SyntaxNode, String)> {
     match diag.kind {
         SemanticDiagnosticKind::UnusedVariable => Fixer.fix_unused_variable(db, diag),
-        SemanticDiagnosticKind::PluginDiagnostic(ref plugin_diag) =>
-            Fixer.fix_plugin_diagnostic(db, diag, plugin_diag),
+        SemanticDiagnosticKind::PluginDiagnostic(ref plugin_diag) => Fixer.fix_plugin_diagnostic(db, diag, plugin_diag),
         SemanticDiagnosticKind::UnusedImport(ref id) => Fixer.fix_unused_import(db, id),
         _ => {
             debug!("No fix available for diagnostic: {:?}", diag.kind);
@@ -70,7 +66,7 @@ impl Fixer {
     pub fn fix_unused_variable(
         &self,
         db: &AnalysisDatabase,
-        diag: &SemanticDiagnostic
+        diag: &SemanticDiagnostic,
     ) -> Option<(SyntaxNode, String)> {
         let node = diag.stable_location.syntax_node(db.upcast());
         let suggestion = format!("_{}", node.get_text(db.upcast()));
@@ -99,29 +95,24 @@ impl Fixer {
         let arms = match_expr.arms(db).elements(db);
         let first_arm = &arms[0];
         let second_arm = &arms[1];
-        let (pattern, first_expr) = match
-            (&first_arm.patterns(db).elements(db)[0], &second_arm.patterns(db).elements(db)[0])
-        {
-            (Pattern::Underscore(_), Pattern::Enum(pat)) => (pat.as_syntax_node(), second_arm),
-            (Pattern::Enum(pat), Pattern::Underscore(_)) => (pat.as_syntax_node(), first_arm),
-            (Pattern::Underscore(_), Pattern::Struct(pat)) => (pat.as_syntax_node(), second_arm),
-            (Pattern::Struct(pat), Pattern::Underscore(_)) => (pat.as_syntax_node(), first_arm),
-            (Pattern::Enum(pat1), Pattern::Enum(pat2)) => {
-                if is_expr_unit(second_arm.expression(db), db) {
-                    (pat1.as_syntax_node(), first_arm)
-                } else {
-                    (pat2.as_syntax_node(), second_arm)
+        let (pattern, first_expr) =
+            match (&first_arm.patterns(db).elements(db)[0], &second_arm.patterns(db).elements(db)[0]) {
+                (Pattern::Underscore(_), Pattern::Enum(pat)) => (pat.as_syntax_node(), second_arm),
+                (Pattern::Enum(pat), Pattern::Underscore(_)) => (pat.as_syntax_node(), first_arm),
+                (Pattern::Underscore(_), Pattern::Struct(pat)) => (pat.as_syntax_node(), second_arm),
+                (Pattern::Struct(pat), Pattern::Underscore(_)) => (pat.as_syntax_node(), first_arm),
+                (Pattern::Enum(pat1), Pattern::Enum(pat2)) => {
+                    if is_expr_unit(second_arm.expression(db), db) {
+                        (pat1.as_syntax_node(), first_arm)
+                    } else {
+                        (pat2.as_syntax_node(), second_arm)
+                    }
                 }
-            }
-            (_, _) => panic!("Incorrect diagnostic"),
-        };
+                (_, _) => panic!("Incorrect diagnostic"),
+            };
         let mut pattern_span = pattern.span(db);
         pattern_span.end = pattern.span_start_without_trivia(db);
-        let indent = node
-            .get_text(db)
-            .chars()
-            .take_while(|c| c.is_whitespace())
-            .collect::<String>();
+        let indent = node.get_text(db).chars().take_while(|c| c.is_whitespace()).collect::<String>();
         let trivia = pattern.clone().get_text_of_span(db, pattern_span).trim().to_string();
         let trivia = if trivia.is_empty() { trivia } else { format!("{indent}{trivia}\n") };
         format!(
@@ -148,14 +139,13 @@ impl Fixer {
         &self,
         db: &AnalysisDatabase,
         semantic_diag: &SemanticDiagnostic,
-        plugin_diag: &PluginDiagnostic
+        plugin_diag: &PluginDiagnostic,
     ) -> Option<(SyntaxNode, String)> {
         let new_text = match diagnostic_kind_from_message(&plugin_diag.message) {
             CairoLintKind::DoubleParens => {
                 self.fix_double_parens(db.upcast(), plugin_diag.stable_ptr.lookup(db.upcast()))
             }
-            CairoLintKind::DestructMatch =>
-                self.fix_destruct_match(db, plugin_diag.stable_ptr.lookup(db.upcast())),
+            CairoLintKind::DestructMatch => self.fix_destruct_match(db, plugin_diag.stable_ptr.lookup(db.upcast())),
             CairoLintKind::LoopForWhile => {
                 // Añade este caso
                 self.fix_loop_break(db.upcast(), plugin_diag.stable_ptr.lookup(db.upcast()))
@@ -193,11 +183,7 @@ impl Fixer {
 
         format!(
             "{}{}",
-            node
-                .get_text(db)
-                .chars()
-                .take_while(|c| c.is_whitespace())
-                .collect::<String>(),
+            node.get_text(db).chars().take_while(|c| c.is_whitespace()).collect::<String>(),
             expr.as_syntax_node().get_text_without_trivia(db)
         )
     }
@@ -221,25 +207,21 @@ impl Fixer {
     /// # Example
     ///
     /// ```
-    /// fn main() {
-    ///     let mut x = 0;
-    ///     loop {
-    ///         if x > 5 {
-    ///             break;
-    ///         }
-    ///         x += 1;
+    /// let mut x = 0;
+    /// loop {
+    ///     if x > 5 {
+    ///         break;
     ///     }
+    ///     x += 1;
     /// }
     /// ```
     ///
     /// Would be converted to:
     ///
     /// ```
-    /// fn main() {
-    ///     let mut x = 0;
-    ///     while x <= 5 {
-    ///         x += 1;
-    ///     }
+    /// let mut x = 0;
+    /// while x <= 5 {
+    ///     x += 1;
     /// }
     /// ```
     pub fn fix_loop_break(&self, db: &dyn SyntaxGroup, node: SyntaxNode) -> String {
@@ -247,13 +229,9 @@ impl Fixer {
         let mut condition_text = String::new();
         let mut loop_body = String::new();
 
-        if
-            let Some(Statement::Expr(expr_statement)) = loop_expr
-                .body(db)
-                .statements(db)
-                .elements(db)
-                .first()
-        {
+        let indent = node.get_text(db).chars().take_while(|c| c.is_whitespace()).collect::<String>();
+
+        if let Some(Statement::Expr(expr_statement)) = loop_expr.body(db).statements(db).elements(db).first() {
             if let Expr::If(if_expr) = expr_statement.expr(db) {
                 let condition = if_expr.condition(db);
                 condition_text = condition.as_syntax_node().get_text_without_trivia(db).to_string();
@@ -263,31 +241,42 @@ impl Fixer {
                 }
 
                 for statement in loop_expr.body(db).statements(db).elements(db).iter().skip(1) {
-                    loop_body.push_str(&statement.as_syntax_node().get_text_without_trivia(db));
-                    loop_body.push('\n');
+                    loop_body.push_str(&format!(
+                        "{}    {}\n",
+                        indent,
+                        statement.as_syntax_node().get_text_without_trivia(db)
+                    ));
                 }
             }
         }
 
-        let original_indent = node
-            .get_text(db)
-            .chars()
-            .take_while(|c| c.is_whitespace())
-            .collect::<String>();
-
-        format!(
-            "{indent}while {condition} {{\n{body}{indent}}}",
-            indent = original_indent,
-            condition = condition_text,
-            body = loop_body
-                .lines()
-                .map(|line| format!("{indent}{line}\n", indent = original_indent))
-                .collect::<String>()
-        )
+        format!("{}while {} {{\n{}{}}}\n", indent, condition_text, loop_body, indent)
     }
 
     fn invert_condition(condition: &str) -> String {
-        if condition.contains('>') {
+        if condition.contains("&&") {
+            condition
+                .split("&&")
+                .map(|part| Self::invert_simple_condition(part.trim()))
+                .collect::<Vec<_>>()
+                .join(" || ")
+        } else if condition.contains("||") {
+            condition
+                .split("||")
+                .map(|part| Self::invert_simple_condition(part.trim()))
+                .collect::<Vec<_>>()
+                .join(" && ")
+        } else {
+            Self::invert_simple_condition(condition)
+        }
+    }
+
+    fn invert_simple_condition(condition: &str) -> String {
+        if condition.contains(">=") {
+            condition.replace(">=", "<")
+        } else if condition.contains("<=") {
+            condition.replace("<=", ">")
+        } else if condition.contains('>') {
             condition.replace('>', "<=")
         } else if condition.contains('<') {
             condition.replace('<', ">=")
@@ -311,11 +300,7 @@ impl Fixer {
     ///
     /// An `Option<(SyntaxNode, String)>` containing the node to be removed and an empty string
     /// (indicating removal). Returns `None` for multi-import paths.
-    pub fn fix_unused_import(
-        &self,
-        db: &AnalysisDatabase,
-        id: &UseId
-    ) -> Option<(SyntaxNode, String)> {
+    pub fn fix_unused_import(&self, db: &AnalysisDatabase, id: &UseId) -> Option<(SyntaxNode, String)> {
         let mut current_node = id.stable_ptr(db).lookup(db.upcast()).as_syntax_node();
         let mut path_to_remove = vec![current_node.clone()];
         let mut remove_entire_statement = true;

--- a/crates/cairo-lint-core/src/lints/loop_for_while.rs
+++ b/crates/cairo-lint-core/src/lints/loop_for_while.rs
@@ -4,22 +4,19 @@ use cairo_lang_syntax::node::ast::{Condition, Expr, ExprLoop, Statement};
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::{TypedStablePtr, TypedSyntaxNode};
 
-pub const LOOP_FOR_WHILE: &str = "unnecessary treatment for loop, use instead while";
+pub const LOOP_FOR_WHILE: &str = "you seem to be trying to use `loop`. Consider replacing this `loop` with a `while` \
+                                  loop for clarity and conciseness";
 
 pub fn check_loop_for_while(db: &dyn SyntaxGroup, loop_expr: &ExprLoop, diagnostics: &mut Vec<PluginDiagnostic>) {
     let body = loop_expr.body(db);
-    let mut has_break = false; // Flag to verify if there is a break
+    let mut has_break = false;
 
     for statement in body.statements(db).elements(db) {
-        // Verify if the statement is an if expression
         if let Statement::Expr(expr_statement) = statement {
             if let Expr::If(if_expr) = expr_statement.expr(db) {
                 let condition = if_expr.condition(db);
-                
-                // Verify if the condition is Let or Expr
                 match condition {
                     Condition::Let(_) | Condition::Expr(_) => {
-                        // Check for a break statement in the if block
                         let if_block = if_expr.if_block(db);
                         for inner_statement in if_block.statements(db).elements(db) {
                             if let Statement::Break(_) = inner_statement {
@@ -33,7 +30,6 @@ pub fn check_loop_for_while(db: &dyn SyntaxGroup, loop_expr: &ExprLoop, diagnost
         }
     }
 
-    // If a break was found, push the diagnostic
     if has_break {
         diagnostics.push(PluginDiagnostic {
             stable_ptr: loop_expr.stable_ptr().untyped(),
@@ -42,4 +38,3 @@ pub fn check_loop_for_while(db: &dyn SyntaxGroup, loop_expr: &ExprLoop, diagnost
         });
     }
 }
-

--- a/crates/cairo-lint-core/src/lints/loop_for_while.rs
+++ b/crates/cairo-lint-core/src/lints/loop_for_while.rs
@@ -1,0 +1,45 @@
+use cairo_lang_defs::plugin::PluginDiagnostic;
+use cairo_lang_diagnostics::Severity;
+use cairo_lang_syntax::node::ast::{Condition, Expr, ExprLoop, Statement};
+use cairo_lang_syntax::node::db::SyntaxGroup;
+use cairo_lang_syntax::node::{TypedStablePtr, TypedSyntaxNode};
+
+pub const LOOP_FOR_WHILE: &str = "unnecessary treatment for loop, use instead while";
+
+pub fn check_loop_for_while(db: &dyn SyntaxGroup, loop_expr: &ExprLoop, diagnostics: &mut Vec<PluginDiagnostic>) {
+    let body = loop_expr.body(db);
+    let mut has_break = false; // Flag to verify if there is a break
+
+    for statement in body.statements(db).elements(db) {
+        // Verify if the statement is an if expression
+        if let Statement::Expr(expr_statement) = statement {
+            if let Expr::If(if_expr) = expr_statement.expr(db) {
+                let condition = if_expr.condition(db);
+                
+                // Verify if the condition is Let or Expr
+                match condition {
+                    Condition::Let(_) | Condition::Expr(_) => {
+                        // Check for a break statement in the if block
+                        let if_block = if_expr.if_block(db);
+                        for inner_statement in if_block.statements(db).elements(db) {
+                            if let Statement::Break(_) = inner_statement {
+                                has_break = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // If a break was found, push the diagnostic
+    if has_break {
+        diagnostics.push(PluginDiagnostic {
+            stable_ptr: loop_expr.stable_ptr().untyped(),
+            message: LOOP_FOR_WHILE.to_string(),
+            severity: Severity::Warning,
+        });
+    }
+}
+

--- a/crates/cairo-lint-core/src/lints/loop_for_while.rs
+++ b/crates/cairo-lint-core/src/lints/loop_for_while.rs
@@ -1,6 +1,6 @@
 use cairo_lang_defs::plugin::PluginDiagnostic;
 use cairo_lang_diagnostics::Severity;
-use cairo_lang_syntax::node::ast::{Condition, Expr, ExprLoop, Statement};
+use cairo_lang_syntax::node::ast::{Expr, ExprLoop, Statement};
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::{TypedStablePtr, TypedSyntaxNode};
 
@@ -12,20 +12,18 @@ pub fn check_loop_for_while(db: &dyn SyntaxGroup, loop_expr: &ExprLoop, diagnost
     let mut has_break = false;
 
     for statement in body.statements(db).elements(db) {
-        if let Statement::Expr(expr_statement) = statement {
-            if let Expr::If(if_expr) = expr_statement.expr(db) {
-                let condition = if_expr.condition(db);
-                match condition {
-                    Condition::Let(_) | Condition::Expr(_) => {
-                        let if_block = if_expr.if_block(db);
-                        for inner_statement in if_block.statements(db).elements(db) {
-                            if let Statement::Break(_) = inner_statement {
-                                has_break = true;
-                                break;
-                            }
-                        }
-                    }
-                }
+        if let Statement::Expr(expr_statement) = statement
+            && let Expr::If(if_expr) = expr_statement.expr(db)
+        {
+            let if_block = if_expr.if_block(db);
+            if if_block
+                .statements(db)
+                .elements(db)
+                .iter()
+                .any(|inner_statement| matches!(inner_statement, Statement::Break(_)))
+            {
+                has_break = true;
+                break;
             }
         }
     }

--- a/crates/cairo-lint-core/src/lints/mod.rs
+++ b/crates/cairo-lint-core/src/lints/mod.rs
@@ -1,3 +1,3 @@
 pub mod double_parens;
-pub mod single_match;
 pub mod loop_for_while;
+pub mod single_match;

--- a/crates/cairo-lint-core/src/lints/mod.rs
+++ b/crates/cairo-lint-core/src/lints/mod.rs
@@ -1,2 +1,3 @@
 pub mod double_parens;
 pub mod single_match;
+pub mod loop_for_while;

--- a/crates/cairo-lint-core/src/plugin.rs
+++ b/crates/cairo-lint-core/src/plugin.rs
@@ -6,7 +6,7 @@ use cairo_lang_syntax::node::ast::{Expr, ExprLoop, ExprMatch};
 use cairo_lang_syntax::node::kind::SyntaxKind;
 use cairo_lang_syntax::node::TypedSyntaxNode;
 
-use crate::lints::{ loop_for_while, double_parens, single_match};
+use crate::lints::{double_parens, loop_for_while, single_match};
 
 pub fn cairo_lint_plugin_suite() -> PluginSuite {
     let mut suite = PluginSuite::default();

--- a/crates/cairo-lint-core/tests/test_files/loop_for_while/loop_for_while
+++ b/crates/cairo-lint-core/tests/test_files/loop_for_while/loop_for_while
@@ -59,7 +59,7 @@ warning: Plugin diagnostic: you seem to be trying to use `loop`. Consider replac
 //! > fixed
 fn main() {
     let mut counter: u16 = 0;
-    while counter <= 5 {
+    while !(counter > 5) {
         counter += 1;
     }
 }
@@ -97,7 +97,7 @@ warning: Plugin diagnostic: you seem to be trying to use `loop`. Consider replac
 fn main() {
     let mut a: u16 = 0;
     let mut b: u16 = 0;
-    while a <= 10 || b >= 5 {
+    while !(a > 10) || !(b < 5) {
         a += 1;
         b += 1;
     }
@@ -132,7 +132,7 @@ warning: Plugin diagnostic: you seem to be trying to use `loop`. Consider replac
 //! > fixed
 fn main() {
     let mut value: u16 = 100;
-    while value >= 0 {
+    while !(value < 0) {
         value -= 10;
     }
 }

--- a/crates/cairo-lint-core/tests/test_files/loop_for_while/loop_for_while
+++ b/crates/cairo-lint-core/tests/test_files/loop_for_while/loop_for_while
@@ -1,9 +1,10 @@
-//! > loop with break and additional code
+//! > loop with arithmetic condition
 
 //! > cairo_code
 fn main() {
+    let mut x: u16 = 5;
     loop {
-        if x > 10 {
+        if x * 2 >= 20 {
             break;
         }
         x += 1;
@@ -11,356 +12,57 @@ fn main() {
 }
 
 //! > diagnostics
-warning: Plugin diagnostic: unnecessary treatment for loop, use instead while
- --> lib.cairo:2:5
+warning: Plugin diagnostic: you seem to be trying to use `loop`. Consider replacing this `loop` with a `while` loop for clarity and conciseness
+ --> lib.cairo:3:5
 \   loop {
-|       if x > 10 {
+|       if x * 2 >= 20 {
 |           break;
 |       }
 |       x += 1;
 |   }
 |___^
 
-error: Identifier not found.
- --> lib.cairo:3:12
-        if x > 10 {
-           ^
-
-error: Identifier not found.
- --> lib.cairo:6:9
-        x += 1;
-        ^
-
 //! > fixed
 fn main() {
-    while x <= 10 {
-        x += 1;
-    }}
-
-//! > ==========================================================================
-
-//! > loop with break and continue
-
-//! > cairo_code
-fn main() {
-    loop {
-        if x > 10 {
-            break;
-        }
-        if x < 0 {
-            continue;
-        }
+    let mut x: u16 = 5;
+    while x * 2 < 20 {
         x += 1;
     }
 }
 
+//! > ==========================================================================
+
+//! > loop with comparison condition
+
+//! > cairo_code
+fn main() {
+    let mut counter: u16 = 0;
+    loop {
+        if counter > 5 {
+            break;
+        }
+        counter += 1;
+    }
+}
+
 //! > diagnostics
-warning: Plugin diagnostic: unnecessary treatment for loop, use instead while
- --> lib.cairo:2:5
+warning: Plugin diagnostic: you seem to be trying to use `loop`. Consider replacing this `loop` with a `while` loop for clarity and conciseness
+ --> lib.cairo:3:5
 \   loop {
-|       if x > 10 {
+|       if counter > 5 {
 |           break;
 |       }
-|       if x < 0 {
-|           continue;
-|       }
-|       x += 1;
+|       counter += 1;
 |   }
 |___^
 
-error: Identifier not found.
- --> lib.cairo:3:12
-        if x > 10 {
-           ^
-
-error: Identifier not found.
- --> lib.cairo:6:12
-        if x < 0 {
-           ^
-
-error: Are you missing a `::`?.
- --> lib.cairo:6:14
-        if x < 0 {
-             ^
-
-error: Identifier not found.
- --> lib.cairo:9:9
-        x += 1;
-        ^
-
 //! > fixed
 fn main() {
-    while x <= 10 {
-        if x < 0 {
-            continue;
-        }
-x += 1;
-    }}
-
-//! > ==========================================================================
-
-//! > loop with break in match expression
-
-//! > cairo_code
-fn main() {
-    loop {
-        match x {
-            0 => continue,
-            10 => break,
-            _ => x += 1,
-        }
+    let mut counter: u16 = 0;
+    while counter <= 5 {
+        counter += 1;
     }
 }
-
-//! > diagnostics
-error: Identifier not found.
- --> lib.cairo:3:15
-        match x {
-              ^
-
-error: Unsupported feature.
- --> lib.cairo:4:18
-            0 => continue,
-                 ^
-
-error: Unsupported feature.
- --> lib.cairo:5:19
-            10 => break,
-                  ^
-
-error: Identifier not found.
- --> lib.cairo:6:18
-            _ => x += 1,
-                 ^
-
-//! > fixed
-fn main() {
-    loop {
-        match x {
-            0 => continue,
-            10 => break,
-            _ => x += 1,
-        }
-    }
-}
-
-//! > ==========================================================================
-
-//! > loop with break in nested if
-
-//! > cairo_code
-fn main() {
-    loop {
-        if x > 0 {
-            if y < 10 {
-                break;
-            }
-        }
-    }
-}
-
-//! > diagnostics
-error: Identifier not found.
- --> lib.cairo:4:16
-            if y < 10 {
-               ^
-
-error: Are you missing a `::`?.
- --> lib.cairo:4:18
-            if y < 10 {
-                 ^
-
-error: Identifier not found.
- --> lib.cairo:3:12
-        if x > 0 {
-           ^
-
-//! > fixed
-Contains nested diagnostics can't fix it
-
-//! > ==========================================================================
-
-//! > loop with complex condition
-
-//! > cairo_code
-fn main() {
-    loop {
-        if x > 10 || (y < 5 && z == 0) {
-            break;
-        }
-    }
-}
-
-//! > diagnostics
-warning: Plugin diagnostic: unnecessary treatment for loop, use instead while
- --> lib.cairo:2:5
-\   loop {
-|       if x > 10 || (y < 5 && z == 0) {
-|           break;
-|       }
-|   }
-|___^
-
-error: Identifier not found.
- --> lib.cairo:3:12
-        if x > 10 || (y < 5 && z == 0) {
-           ^
-
-error: Identifier not found.
- --> lib.cairo:3:23
-        if x > 10 || (y < 5 && z == 0) {
-                      ^
-
-error: Are you missing a `::`?.
- --> lib.cairo:3:25
-        if x > 10 || (y < 5 && z == 0) {
-                        ^
-
-error: Identifier not found.
- --> lib.cairo:3:32
-        if x > 10 || (y < 5 && z == 0) {
-                               ^
-
-//! > fixed
-fn main() {
-    while x <= 10 || (y < 5 && z == 0) {
-        
-    }}
-
-//! > ==========================================================================
-
-//! > loop with early return
-
-//! > cairo_code
-fn main() -> felt252 {
-    loop {
-        if x > 10 {
-            return x;
-        }
-        x += 1;
-    }
-}
-
-//! > diagnostics
-error: `return` not allowed inside a `loop`.
- --> lib.cairo:4:13
-            return x;
-            ^*******^
-
-error: Identifier not found.
- --> lib.cairo:3:12
-        if x > 10 {
-           ^
-
-error: Identifier not found.
- --> lib.cairo:6:9
-        x += 1;
-        ^
-
-//! > fixed
-fn main() -> felt252 {
-    loop {
-        if x > 10 {
-            return x;
-        }
-        x += 1;
-    }
-}
-
-//! > ==========================================================================
-
-//! > loop with else clause
-
-//! > cairo_code
-fn main() {
-    loop {
-        if x > 10 {
-            break;
-        } else {
-            x += 1;
-        }
-    }
-}
-
-//! > diagnostics
-warning: Plugin diagnostic: unnecessary treatment for loop, use instead while
- --> lib.cairo:2:5
-\   loop {
-|       if x > 10 {
-|           break;
-|       } else {
-|           x += 1;
-|       }
-|   }
-|___^
-
-error: Identifier not found.
- --> lib.cairo:3:12
-        if x > 10 {
-           ^
-
-error: Identifier not found.
- --> lib.cairo:6:13
-            x += 1;
-            ^
-
-//! > fixed
-fn main() {
-    while x <= 10 {
-        
-    }}
-
-//! > ==========================================================================
-
-//! > loop with multiple breaks
-
-//! > cairo_code
-fn main() {
-    loop {
-        if x > 10 {
-            break;
-        }
-        if y < 0 {
-            break;
-        }
-    }
-}
-
-//! > diagnostics
-warning: Plugin diagnostic: unnecessary treatment for loop, use instead while
- --> lib.cairo:2:5
-\   loop {
-|       if x > 10 {
-|           break;
-|       }
-|       if y < 0 {
-|           break;
-|       }
-|   }
-|___^
-
-error: Identifier not found.
- --> lib.cairo:3:12
-        if x > 10 {
-           ^
-
-error: Identifier not found.
- --> lib.cairo:6:12
-        if y < 0 {
-           ^
-
-error: Are you missing a `::`?.
- --> lib.cairo:6:14
-        if y < 0 {
-             ^
-
-//! > fixed
-fn main() {
-    while x <= 10 {
-        if y < 0 {
-            break;
-        }
-    }}
 
 //! > ==========================================================================
 
@@ -368,43 +70,72 @@ fn main() {
 
 //! > cairo_code
 fn main() {
+    let mut a: u16 = 0;
+    let mut b: u16 = 0;
     loop {
-        if x > 10 && y < 5 {
+        if a > 10 && b < 5 {
             break;
         }
+        a += 1;
+        b += 1;
     }
 }
 
 //! > diagnostics
-warning: Plugin diagnostic: unnecessary treatment for loop, use instead while
- --> lib.cairo:2:5
+warning: Plugin diagnostic: you seem to be trying to use `loop`. Consider replacing this `loop` with a `while` loop for clarity and conciseness
+ --> lib.cairo:4:5
 \   loop {
-|       if x > 10 && y < 5 {
+|       if a > 10 && b < 5 {
 |           break;
 |       }
+|       a += 1;
+|       b += 1;
 |   }
 |___^
 
-error: Identifier not found.
- --> lib.cairo:3:12
-        if x > 10 && y < 5 {
-           ^
+//! > fixed
+fn main() {
+    let mut a: u16 = 0;
+    let mut b: u16 = 0;
+    while a <= 10 || b >= 5 {
+        a += 1;
+        b += 1;
+    }
+}
 
-error: Identifier not found.
- --> lib.cairo:3:22
-        if x > 10 && y < 5 {
-                     ^
+//! > ==========================================================================
 
-error: Are you missing a `::`?.
- --> lib.cairo:3:24
-        if x > 10 && y < 5 {
-                       ^
+//! > loop with negative condition
+
+//! > cairo_code
+fn main() {
+    let mut value: u16 = 100;
+    loop {
+        if value < 0 {
+            break;
+        }
+        value -= 10;
+    }
+}
+
+//! > diagnostics
+warning: Plugin diagnostic: you seem to be trying to use `loop`. Consider replacing this `loop` with a `while` loop for clarity and conciseness
+ --> lib.cairo:3:5
+\   loop {
+|       if value < 0 {
+|           break;
+|       }
+|       value -= 10;
+|   }
+|___^
 
 //! > fixed
 fn main() {
-    while x <= 10 && y < 5 {
-        
-    }}
+    let mut value: u16 = 100;
+    while value >= 0 {
+        value -= 10;
+    }
+}
 
 //! > ==========================================================================
 
@@ -412,30 +143,30 @@ fn main() {
 
 //! > cairo_code
 fn main() {
+    let mut x: u16 = 0;
     loop {
-        if x > 10 {
+        if x == 10 {
             break;
         }
+        x += 1;
     }
 }
 
 //! > diagnostics
-warning: Plugin diagnostic: unnecessary treatment for loop, use instead while
- --> lib.cairo:2:5
+warning: Plugin diagnostic: you seem to be trying to use `loop`. Consider replacing this `loop` with a `while` loop for clarity and conciseness
+ --> lib.cairo:3:5
 \   loop {
-|       if x > 10 {
+|       if x == 10 {
 |           break;
 |       }
+|       x += 1;
 |   }
 |___^
 
-error: Identifier not found.
- --> lib.cairo:3:12
-        if x > 10 {
-           ^
-
 //! > fixed
 fn main() {
-    while x <= 10 {
-        
-    }}
+    let mut x: u16 = 0;
+    while !(x == 10) {
+        x += 1;
+    }
+}

--- a/crates/cairo-lint-core/tests/test_files/loop_for_while/loop_for_while
+++ b/crates/cairo-lint-core/tests/test_files/loop_for_while/loop_for_while
@@ -1,9 +1,191 @@
-//! > loop with simple if and break
+//! > loop with break and additional code
 
 //! > cairo_code
 fn main() {
     loop {
-        if true {
+        if x > 10 {
+            break;
+        }
+        x += 1;
+    }
+}
+
+//! > diagnostics
+warning: Plugin diagnostic: unnecessary treatment for loop, use instead while
+ --> lib.cairo:2:5
+\   loop {
+|       if x > 10 {
+|           break;
+|       }
+|       x += 1;
+|   }
+|___^
+
+error: Identifier not found.
+ --> lib.cairo:3:12
+        if x > 10 {
+           ^
+
+error: Identifier not found.
+ --> lib.cairo:6:9
+        x += 1;
+        ^
+
+//! > fixed
+fn main() {
+    while x <= 10 {
+        x += 1;
+    }}
+
+//! > ==========================================================================
+
+//! > loop with break and continue
+
+//! > cairo_code
+fn main() {
+    loop {
+        if x > 10 {
+            break;
+        }
+        if x < 0 {
+            continue;
+        }
+        x += 1;
+    }
+}
+
+//! > diagnostics
+warning: Plugin diagnostic: unnecessary treatment for loop, use instead while
+ --> lib.cairo:2:5
+\   loop {
+|       if x > 10 {
+|           break;
+|       }
+|       if x < 0 {
+|           continue;
+|       }
+|       x += 1;
+|   }
+|___^
+
+error: Identifier not found.
+ --> lib.cairo:3:12
+        if x > 10 {
+           ^
+
+error: Identifier not found.
+ --> lib.cairo:6:12
+        if x < 0 {
+           ^
+
+error: Are you missing a `::`?.
+ --> lib.cairo:6:14
+        if x < 0 {
+             ^
+
+error: Identifier not found.
+ --> lib.cairo:9:9
+        x += 1;
+        ^
+
+//! > fixed
+fn main() {
+    while x <= 10 {
+        if x < 0 {
+            continue;
+        }
+x += 1;
+    }}
+
+//! > ==========================================================================
+
+//! > loop with break in match expression
+
+//! > cairo_code
+fn main() {
+    loop {
+        match x {
+            0 => continue,
+            10 => break,
+            _ => x += 1,
+        }
+    }
+}
+
+//! > diagnostics
+error: Identifier not found.
+ --> lib.cairo:3:15
+        match x {
+              ^
+
+error: Unsupported feature.
+ --> lib.cairo:4:18
+            0 => continue,
+                 ^
+
+error: Unsupported feature.
+ --> lib.cairo:5:19
+            10 => break,
+                  ^
+
+error: Identifier not found.
+ --> lib.cairo:6:18
+            _ => x += 1,
+                 ^
+
+//! > fixed
+fn main() {
+    loop {
+        match x {
+            0 => continue,
+            10 => break,
+            _ => x += 1,
+        }
+    }
+}
+
+//! > ==========================================================================
+
+//! > loop with break in nested if
+
+//! > cairo_code
+fn main() {
+    loop {
+        if x > 0 {
+            if y < 10 {
+                break;
+            }
+        }
+    }
+}
+
+//! > diagnostics
+error: Identifier not found.
+ --> lib.cairo:4:16
+            if y < 10 {
+               ^
+
+error: Are you missing a `::`?.
+ --> lib.cairo:4:18
+            if y < 10 {
+                 ^
+
+error: Identifier not found.
+ --> lib.cairo:3:12
+        if x > 0 {
+           ^
+
+//! > fixed
+Contains nested diagnostics can't fix it
+
+//! > ==========================================================================
+
+//! > loop with complex condition
+
+//! > cairo_code
+fn main() {
+    loop {
+        if x > 10 || (y < 5 && z == 0) {
             break;
         }
     }
@@ -13,15 +195,247 @@ fn main() {
 warning: Plugin diagnostic: unnecessary treatment for loop, use instead while
  --> lib.cairo:2:5
 \   loop {
-|       if true {
+|       if x > 10 || (y < 5 && z == 0) {
 |           break;
 |       }
 |   }
 |___^
 
+error: Identifier not found.
+ --> lib.cairo:3:12
+        if x > 10 || (y < 5 && z == 0) {
+           ^
+
+error: Identifier not found.
+ --> lib.cairo:3:23
+        if x > 10 || (y < 5 && z == 0) {
+                      ^
+
+error: Are you missing a `::`?.
+ --> lib.cairo:3:25
+        if x > 10 || (y < 5 && z == 0) {
+                        ^
+
+error: Identifier not found.
+ --> lib.cairo:3:32
+        if x > 10 || (y < 5 && z == 0) {
+                               ^
+
 //! > fixed
 fn main() {
-    while !true {
+    while x <= 10 || (y < 5 && z == 0) {
+        
+    }}
 
+//! > ==========================================================================
+
+//! > loop with early return
+
+//! > cairo_code
+fn main() -> felt252 {
+    loop {
+        if x > 10 {
+            return x;
+        }
+        x += 1;
     }
 }
+
+//! > diagnostics
+error: `return` not allowed inside a `loop`.
+ --> lib.cairo:4:13
+            return x;
+            ^*******^
+
+error: Identifier not found.
+ --> lib.cairo:3:12
+        if x > 10 {
+           ^
+
+error: Identifier not found.
+ --> lib.cairo:6:9
+        x += 1;
+        ^
+
+//! > fixed
+fn main() -> felt252 {
+    loop {
+        if x > 10 {
+            return x;
+        }
+        x += 1;
+    }
+}
+
+//! > ==========================================================================
+
+//! > loop with else clause
+
+//! > cairo_code
+fn main() {
+    loop {
+        if x > 10 {
+            break;
+        } else {
+            x += 1;
+        }
+    }
+}
+
+//! > diagnostics
+warning: Plugin diagnostic: unnecessary treatment for loop, use instead while
+ --> lib.cairo:2:5
+\   loop {
+|       if x > 10 {
+|           break;
+|       } else {
+|           x += 1;
+|       }
+|   }
+|___^
+
+error: Identifier not found.
+ --> lib.cairo:3:12
+        if x > 10 {
+           ^
+
+error: Identifier not found.
+ --> lib.cairo:6:13
+            x += 1;
+            ^
+
+//! > fixed
+fn main() {
+    while x <= 10 {
+        
+    }}
+
+//! > ==========================================================================
+
+//! > loop with multiple breaks
+
+//! > cairo_code
+fn main() {
+    loop {
+        if x > 10 {
+            break;
+        }
+        if y < 0 {
+            break;
+        }
+    }
+}
+
+//! > diagnostics
+warning: Plugin diagnostic: unnecessary treatment for loop, use instead while
+ --> lib.cairo:2:5
+\   loop {
+|       if x > 10 {
+|           break;
+|       }
+|       if y < 0 {
+|           break;
+|       }
+|   }
+|___^
+
+error: Identifier not found.
+ --> lib.cairo:3:12
+        if x > 10 {
+           ^
+
+error: Identifier not found.
+ --> lib.cairo:6:12
+        if y < 0 {
+           ^
+
+error: Are you missing a `::`?.
+ --> lib.cairo:6:14
+        if y < 0 {
+             ^
+
+//! > fixed
+fn main() {
+    while x <= 10 {
+        if y < 0 {
+            break;
+        }
+    }}
+
+//! > ==========================================================================
+
+//! > loop with multiple conditions
+
+//! > cairo_code
+fn main() {
+    loop {
+        if x > 10 && y < 5 {
+            break;
+        }
+    }
+}
+
+//! > diagnostics
+warning: Plugin diagnostic: unnecessary treatment for loop, use instead while
+ --> lib.cairo:2:5
+\   loop {
+|       if x > 10 && y < 5 {
+|           break;
+|       }
+|   }
+|___^
+
+error: Identifier not found.
+ --> lib.cairo:3:12
+        if x > 10 && y < 5 {
+           ^
+
+error: Identifier not found.
+ --> lib.cairo:3:22
+        if x > 10 && y < 5 {
+                     ^
+
+error: Are you missing a `::`?.
+ --> lib.cairo:3:24
+        if x > 10 && y < 5 {
+                       ^
+
+//! > fixed
+fn main() {
+    while x <= 10 && y < 5 {
+        
+    }}
+
+//! > ==========================================================================
+
+//! > simple loop with break
+
+//! > cairo_code
+fn main() {
+    loop {
+        if x > 10 {
+            break;
+        }
+    }
+}
+
+//! > diagnostics
+warning: Plugin diagnostic: unnecessary treatment for loop, use instead while
+ --> lib.cairo:2:5
+\   loop {
+|       if x > 10 {
+|           break;
+|       }
+|   }
+|___^
+
+error: Identifier not found.
+ --> lib.cairo:3:12
+        if x > 10 {
+           ^
+
+//! > fixed
+fn main() {
+    while x <= 10 {
+        
+    }}

--- a/crates/cairo-lint-core/tests/test_files/loop_for_while/loop_for_while
+++ b/crates/cairo-lint-core/tests/test_files/loop_for_while/loop_for_while
@@ -1,0 +1,13 @@
+//! > loop with simple if and break
+
+//! > cairo_code
+fn main() {
+    let mut i: usize = 0;
+    loop {
+        if i > 10 {
+            break;
+        }
+        i += 1;
+    }
+}
+

--- a/crates/cairo-lint-core/tests/test_files/loop_for_while/loop_for_while
+++ b/crates/cairo-lint-core/tests/test_files/loop_for_while/loop_for_while
@@ -2,12 +2,26 @@
 
 //! > cairo_code
 fn main() {
-    let mut i: usize = 0;
     loop {
-        if i > 10 {
+        if true {
             break;
         }
-        i += 1;
     }
 }
 
+//! > diagnostics
+warning: Plugin diagnostic: unnecessary treatment for loop, use instead while
+ --> lib.cairo:2:5
+\   loop {
+|       if true {
+|           break;
+|       }
+|   }
+|___^
+
+//! > fixed
+fn main() {
+    while !true {
+
+    }
+}

--- a/crates/cairo-lint-core/tests/tests.rs
+++ b/crates/cairo-lint-core/tests/tests.rs
@@ -66,6 +66,17 @@ test_file!(
     "double parens in match arm"
 );
 
-test_file!(loop_for_while, 
+test_file!(
     loop_for_while, 
-    "loop with simple if and break");
+    loop_for_while, 
+    "simple loop with break",
+    "loop with break and additional code",
+    "loop with multiple conditions",
+    "loop with else clause",
+    "loop with break in nested if",
+    "loop with multiple breaks",
+    "loop with break and continue",
+    "loop with complex condition",
+    "loop with break in match expression",
+    "loop with early return"
+);

--- a/crates/cairo-lint-core/tests/tests.rs
+++ b/crates/cairo-lint-core/tests/tests.rs
@@ -67,16 +67,11 @@ test_file!(
 );
 
 test_file!(
-    loop_for_while, 
-    loop_for_while, 
+    loop_for_while,
+    loop_for_while,
     "simple loop with break",
-    "loop with break and additional code",
-    "loop with multiple conditions",
-    "loop with else clause",
-    "loop with break in nested if",
-    "loop with multiple breaks",
-    "loop with break and continue",
-    "loop with complex condition",
-    "loop with break in match expression",
-    "loop with early return"
+    "loop with comparison condition",
+    "loop with negative condition",
+    "loop with arithmetic condition",
+    "loop with multiple conditions"
 );

--- a/crates/cairo-lint-core/tests/tests.rs
+++ b/crates/cairo-lint-core/tests/tests.rs
@@ -65,3 +65,7 @@ test_file!(
     "double parens in struct field access",
     "double parens in match arm"
 );
+
+test_file!(loop_for_while, 
+    loop_for_while, 
+    "loop with simple if and break");


### PR DESCRIPTION
## Summary 📌

This PR closes issue #34 

This PR introduces a new lint `loop_for_while` that detects and suggests replacing unnecessary `loop` constructs with `while` loops, improving code clarity and conciseness.

## Changes Made ⚡️

### Implementation of `loop_for_while` Lint
- Added a new lint in **`plugin.rs`** to detect `loop` constructs that can be replaced by `while` loops.
- Implemented the fix logic in **`fix.rs`**, ensuring that the conversion from `loop` to `while` preserves the original logic while simplifying the code structure.
- Added diagnostic and fix logic in **`loop_for_while.rs`** to handle conditions and loop bodies appropriately.

### Test Coverage 🥷🏼
- Added test cases in **`test_files/loop_for_while`** to validate the `loop_for_while` lint:
  - Conversion of a simple `loop` with a comparison condition to a `while`.
  - Handling of `loop` with multiple conditions involving logical operators.
  - Conversion of a `loop` with arithmetic conditions.
  - Ensured that the `while` loop correctly reflects the logic of the original `loop`.

### Test Results ✅

All tests have passed successfully, confirming that the `loop_for_while` lint works as intended and improves the readability of the code.

<img width="806" alt="image" src="https://github.com/user-attachments/assets/a65f31ed-013b-485e-885b-adbadad1fbdd">
