### PR TITLE
feat: add useless conversion lint

### DIFF
--- a/crates/cairo-lint-core/src/lints/mod.rs
+++ b/crates/cairo-lint-core/src/lints/mod.rs
@@ -4,3 +4,4 @@ pub mod double_comparison;
 pub mod double_parens;
 pub mod loops;
 pub mod single_match;
+pub mod useless_conversion;

--- a/crates/cairo-lint-core/src/lints/useless_conversion.rs
+++ b/crates/cairo-lint-core/src/lints/useless_conversion.rs
@@ -1,0 +1,44 @@
+use cairo_lang_defs::plugin::PluginDiagnostic;
+use cairo_lang_diagnostics::Severity;
+use cairo_lang_syntax::node::ast::ExprFunctionCall;
+use cairo_lang_syntax::node::db::SyntaxGroup;
+use cairo_lang_syntax::node::ids::SyntaxStablePtrId;
+use cairo_lang_syntax::node::{TypedStablePtr, TypedSyntaxNode};
+
+pub const USELESS_CONVERSION: &str = "This conversion is unnecessary.";
+
+pub fn check_useless_conversion(
+    db: &dyn SyntaxGroup,
+    function_call: &ExprFunctionCall,
+    diagnostics: &mut Vec<PluginDiagnostic>,
+) {
+    let callee = function_call.as_syntax_node().get_text_without_trivia(db);
+
+    if callee.ends_with(".into()") {
+        let argument_type = determine_type_of_expr(function_call, db);
+        let expected_type = determine_expected_type(db, function_call);
+
+        // If the type of the expression and the expected type are the same, it's a useless conversion
+        if let (Some(arg_type), Some(exp_type)) = (argument_type, expected_type) {
+            if arg_type == exp_type {
+                diagnostics.push(create_diagnostic(
+                    USELESS_CONVERSION,
+                    function_call.stable_ptr().untyped(),
+                    Severity::Warning,
+                ));
+            }
+        }
+    }
+}
+
+fn determine_type_of_expr(expr: &ExprFunctionCall, db: &dyn SyntaxGroup) -> Option<String> {    
+    Some(expr.as_syntax_node().get_text_without_trivia(db))
+}
+
+fn determine_expected_type(db: &dyn SyntaxGroup, function_call: &ExprFunctionCall) -> Option<String> {    
+    Some("String".to_string())
+}
+
+fn create_diagnostic(message: &str, stable_ptr: SyntaxStablePtrId, severity: Severity) -> PluginDiagnostic {
+    PluginDiagnostic { stable_ptr, message: message.to_string(), severity }
+}

--- a/crates/cairo-lint-core/src/plugin.rs
+++ b/crates/cairo-lint-core/src/plugin.rs
@@ -3,11 +3,13 @@ use cairo_lang_defs::plugin::PluginDiagnostic;
 use cairo_lang_semantic::db::SemanticGroup;
 use cairo_lang_semantic::plugin::{AnalyzerPlugin, PluginSuite};
 use cairo_lang_semantic::Expr;
-use cairo_lang_syntax::node::ast::{Expr as AstExpr, ExprBinary};
+use cairo_lang_syntax::node::ast::{Expr as AstExpr, ExprBinary, ExprFunctionCall};
 use cairo_lang_syntax::node::kind::SyntaxKind;
 use cairo_lang_syntax::node::{TypedStablePtr, TypedSyntaxNode};
 
-use crate::lints::{bool_comparison, breaks, double_comparison, double_parens, loops, single_match};
+use crate::lints::{
+    bool_comparison, breaks, double_comparison, double_parens, loops, single_match, useless_conversion,
+};
 
 pub fn cairo_lint_plugin_suite() -> PluginSuite {
     let mut suite = PluginSuite::default();
@@ -22,6 +24,7 @@ pub enum CairoLintKind {
     DestructMatch,
     MatchForEquality,
     DoubleComparison,
+    UselessConversion,
     DoubleParens,
     Unknown,
     BreakUnit,
@@ -36,6 +39,7 @@ pub fn diagnostic_kind_from_message(message: &str) -> CairoLintKind {
         double_comparison::SIMPLIFIABLE_COMPARISON => CairoLintKind::DoubleComparison,
         double_comparison::REDUNDANT_COMPARISON => CairoLintKind::DoubleComparison,
         double_comparison::CONTRADICTORY_COMPARISON => CairoLintKind::DoubleComparison,
+        useless_conversion::USELESS_CONVERSION => CairoLintKind::UselessConversion,
         breaks::BREAK_UNIT => CairoLintKind::BreakUnit,
         bool_comparison::BOOL_COMPARISON => CairoLintKind::BoolComparison,
         _ => CairoLintKind::Unknown,
@@ -93,6 +97,13 @@ impl AnalyzerPlugin for CairoLint {
                         double_comparison::check_double_comparison(db.upcast(), &expr_binary, &mut diags);
                     }
                     SyntaxKind::StatementBreak => breaks::check_break(db.upcast(), node, &mut diags),
+                    SyntaxKind::ExprFunctionCall => {
+                        useless_conversion::check_useless_conversion(
+                            db.upcast(),
+                            &ExprFunctionCall::from_syntax_node(db.upcast(), node),
+                            &mut diags,
+                        );
+                    }
                     _ => continue,
                 }
             }

--- a/crates/cairo-lint-core/tests/test_files/useless_conversion/useless_conversion
+++ b/crates/cairo-lint-core/tests/test_files/useless_conversion/useless_conversion
@@ -1,0 +1,168 @@
+//! > nested useless conversions
+
+//! > cairo_code
+fn main() -> felt {
+    let x: felt = 20.into().into();
+    x
+}
+
+//! > diagnostics
+error: Type not found.
+--> lib.cairo:0:14
+ |
+0 | fn main() -> felt {
+ |              ^^^^
+ |
+error: Type not found.
+ --> lib.cairo:2:12
+  |
+2 |     let x: felt = 20.into().into();
+  |            ^^^^
+  |
+
+//! > fixed
+Contains nested diagnostics can't fix it
+
+//! > ==========================================================================
+
+//! > useless conversion from felt to felt with try_into
+
+//! > cairo_code
+fn main() -> felt {
+    let x: felt = 10.try_into().unwrap();
+    x
+}
+
+//! > diagnostics
+error: Type not found.
+--> lib.cairo:0:14
+ |
+0 | fn main() -> felt {
+ |              ^^^^
+ |
+error: Type not found.
+ --> lib.cairo:2:12
+  |
+2 |     let x: felt = 10.try_into().unwrap();
+  |            ^^^^
+  |
+
+//! > fixed
+fn main() -> felt {
+    let x: felt = 10.try_into().unwrap();
+    x
+}
+
+//! > ==========================================================================
+
+//! > useless conversion from felt252 to felt252
+
+//! > cairo_code
+fn main() -> felt252 {
+    let x: felt252 = 100.into();
+    x
+}
+
+//! > diagnostics
+
+//! > fixed
+fn main() -> felt252 {
+    let x: felt252 = 100.into();
+    x
+}
+
+//! > ==========================================================================
+
+//! > useless conversion in complex expression
+
+//! > cairo_code
+fn main() -> felt {
+    let x: felt = 42;
+    let y: felt = (x + 10).into();
+    y
+}
+
+//! > diagnostics
+error: Type not found.
+--> lib.cairo:0:14
+ |
+0 | fn main() -> felt {
+ |              ^^^^
+ |
+error: Type not found.
+ --> lib.cairo:2:12
+  |
+2 |     let x: felt = 42;
+  |            ^^^^
+  |
+error: Type not found.
+ --> lib.cairo:4:12
+  |
+4 |     let y: felt = (x + 10).into();
+  |            ^^^^
+  |
+
+//! > fixed
+fn main() -> felt {
+    let x: felt = 42;
+    let y: felt = (x + 10).into();
+    y
+}
+
+//! > ==========================================================================
+
+//! > valid conversion from felt to felt252
+
+//! > cairo_code
+fn main() -> felt252 {
+    let x: felt = 5;
+    let y: felt252 = x.into();
+    y
+}
+
+//! > diagnostics
+error: Type not found.
+ --> lib.cairo:2:12
+  |
+2 |     let x: felt = 5;
+  |            ^^^^
+  |
+
+//! > fixed
+fn main() -> felt252 {
+    let x: felt = 5;
+    let y: felt252 = x.into();
+    y
+}
+
+//! > ==========================================================================
+
+//! > valid try_into conversion
+
+//! > cairo_code
+fn main() -> Option<felt252> {
+    let x: felt = 5;
+    let y: Result<felt252, _> = x.try_into();
+    y.ok()
+}
+
+//! > diagnostics
+error: Type not found.
+ --> lib.cairo:2:12
+  |
+2 |     let x: felt = 5;
+  |            ^^^^
+  |
+error: Unexpected argument type. Expected: "core::result::Result::<core::felt252, ?1>", found: "core::option::Option::<?3>".
+ --> lib.cairo:4:33
+  |
+4 |     let y: Result<felt252, _> = x.try_into();
+  |                                 ^^^^^^^^^^^^
+  |
+
+//! > fixed
+fn main() -> Option<felt252> {
+    let x: felt = 5;
+    let y: Result<felt252, _> = x.try_into();
+    y.ok()
+}

--- a/crates/cairo-lint-core/tests/tests.rs
+++ b/crates/cairo-lint-core/tests/tests.rs
@@ -110,3 +110,14 @@ test_file!(
     "Negated comparison with false",
     "Negated comparison with false on LHS"
 );
+
+test_file!(
+    useless_conversion,
+    useless_conversion,
+    "useless conversion from felt to felt with try_into",
+    "useless conversion from felt252 to felt252",
+    "valid conversion from felt to felt252",
+    "useless conversion in complex expression",
+    "valid try_into conversion",
+    "nested useless conversions"
+);


### PR DESCRIPTION
Closes #55 

**Changes Introduced**
Added useless_conversion Lint

This is a draft, I need some help with the implementation of the `determine_type_of_expr `and `determine_expected_type ` methods.