### PR TITLE
refactor: manual lints

### DIFF
--- a/crates/cairo-lint-core/src/lints/manual/manual.rs
+++ b/crates/cairo-lint-core/src/lints/manual/manual.rs
@@ -1,0 +1,65 @@
+use cairo_lang_syntax::node::ast::{Expr, ExprMatch, Pattern};
+use cairo_lang_syntax::node::db::SyntaxGroup;
+use cairo_lang_syntax::node::TypedSyntaxNode;
+
+#[derive(Copy, Clone, Debug)]
+pub enum ManualLint {
+    ManualOkOr,
+}
+pub fn check_manual(db: &dyn SyntaxGroup, expr_match: &ExprMatch, manual_lint: ManualLint) -> bool {
+    let arms = expr_match.arms(db).elements(db);
+
+    if arms.len() != 2 {
+        return false;
+    }
+
+    let first_arm = &arms[0];
+    let second_arm = &arms[1];
+
+    let found_some = match &first_arm.patterns(db).elements(db)[0] {
+        Pattern::Enum(enum_pattern) => {
+            let enum_name = enum_pattern.path(db).as_syntax_node().get_text_without_trivia(db);
+            match enum_name.as_str() {
+                "Option::Some" => check_syntax_some_expression(first_arm.expression(db), db, manual_lint),
+                _ => false,
+            }
+        }
+        _ => false,
+    };
+
+    let found_none = match &second_arm.patterns(db).elements(db)[0] {
+        Pattern::Enum(enum_pattern) => {
+            let enum_name = enum_pattern.path(db).as_syntax_node().get_text_without_trivia(db);
+            match enum_name.as_str() {
+                "Option::None" => check_syntax_none_expression(second_arm.expression(db), db, manual_lint),
+                _ => false,
+            }
+        }
+        _ => false,
+    };
+
+    found_some && found_none
+}
+
+fn check_syntax_some_expression(arm_expression: Expr, db: &dyn SyntaxGroup, manual_lint: ManualLint) -> bool {
+    match manual_lint {
+        ManualLint::ManualOkOr => {
+            if let Expr::FunctionCall(func_call) = arm_expression {
+                return func_call.path(db).as_syntax_node().get_text(db) == "Result::Ok";
+            }
+        }
+    }
+    false
+}
+
+fn check_syntax_none_expression(arm_expression: Expr, db: &dyn SyntaxGroup, manual_lint: ManualLint) -> bool {
+    match manual_lint {
+        ManualLint::ManualOkOr => {
+            if let Expr::FunctionCall(func_call) = arm_expression {
+                return func_call.path(db).as_syntax_node().get_text(db) == "Result::Err";
+            }
+        }
+    }
+
+    false
+}

--- a/crates/cairo-lint-core/src/lints/manual/manual_ok_or.rs
+++ b/crates/cairo-lint-core/src/lints/manual/manual_ok_or.rs
@@ -1,69 +1,19 @@
 use cairo_lang_defs::plugin::PluginDiagnostic;
 use cairo_lang_diagnostics::Severity;
-use cairo_lang_syntax::node::ast::{Expr, ExprMatch, Pattern};
+use cairo_lang_syntax::node::ast::ExprMatch;
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::TypedSyntaxNode;
 
+use crate::lints::manual::manual::{check_manual, ManualLint};
+
 pub const MANUAL_OK_OR: &str = "Manual match for Option<T> detected. Consider using ok_or instead";
 
-pub const SOME_VARIANT: &str = "Some";
-pub const NONE_VARIANT: &str = "None";
-
 pub fn check_manual_ok_or(db: &dyn SyntaxGroup, expr_match: &ExprMatch, diagnostics: &mut Vec<PluginDiagnostic>) {
-    let arms = expr_match.arms(db).elements(db);
-
-    if arms.len() != 2 {
-        return;
-    }
-
-    let first_arm = &arms[0];
-    let second_arm = &arms[1];
-
-    let first_pattern = &first_arm.patterns(db).elements(db)[0];
-    let second_pattern = &second_arm.patterns(db).elements(db)[0];
-
-    // Checks if the pattern matches Option::Some(v) => Result::Ok(v)
-    let found_some_ok = match first_pattern {
-        Pattern::Enum(enum_pattern) => {
-            let enum_name = enum_pattern.path(db).as_syntax_node().get_text_without_trivia(db);
-            match enum_name.as_str() {
-                "Option::Some" => check_syntax_enum_pattern(first_arm.expression(db), db, SOME_VARIANT),
-                _ => false,
-            }
-        }
-        _ => false,
-    };
-
-    // Checks if the pattern matches Option::None => Result::Err('this is an err')
-    let found_none_err = match second_pattern {
-        Pattern::Enum(enum_pattern) => {
-            let enum_name = enum_pattern.path(db).as_syntax_node().get_text_without_trivia(db);
-            match enum_name.as_str() {
-                "Option::None" => check_syntax_enum_pattern(second_arm.expression(db), db, NONE_VARIANT),
-                _ => false,
-            }
-        }
-        _ => false,
-    };
-
-    if found_some_ok && found_none_err {
+    if check_manual(db, expr_match, ManualLint::ManualOkOr) {
         diagnostics.push(PluginDiagnostic {
             stable_ptr: expr_match.as_syntax_node().stable_ptr(),
             message: MANUAL_OK_OR.to_owned(),
             severity: Severity::Warning,
         });
     }
-}
-
-fn check_syntax_enum_pattern(arm_expression: Expr, db: &dyn SyntaxGroup, variant_name: &str) -> bool {
-    if let Expr::FunctionCall(func_call) = arm_expression {
-        let func_name = func_call.path(db).as_syntax_node().get_text(db);
-        if (variant_name == SOME_VARIANT && func_name == "Result::Ok")
-            || (variant_name == NONE_VARIANT && func_name == "Result::Err")
-        {
-            return true;
-        }
-    }
-
-    false
 }

--- a/crates/cairo-lint-core/src/lints/manual/mod.rs
+++ b/crates/cairo-lint-core/src/lints/manual/mod.rs
@@ -1,1 +1,2 @@
+pub mod manual;
 pub mod manual_ok_or;


### PR DESCRIPTION
Resolves discussion in : #105 

* Introduces `check_manual` to avoid duplicated code in manual lints
* Trims `fix_manual_ok_or`