### PR TITLE
feat: Adds invisible character detection logic and updates tests

### DIFF
--- a/crates/cairo-lint-core/src/fix.rs
+++ b/crates/cairo-lint-core/src/fix.rs
@@ -169,7 +169,7 @@ impl Fixer {
             CairoLintKind::DoubleComparison => {
                 self.fix_double_comparison(db.upcast(), plugin_diag.stable_ptr.lookup(db.upcast()))
             }
-            CairoLintKind::InvisibleCharacters => {
+            CairoLintKind::InvisibleCharacters => { 
                 self.fix_whitespace_issues(db, plugin_diag.stable_ptr.lookup(db.upcast()))
             }
             CairoLintKind::EquatableIfLet => self.fix_equatable_if_let(db, plugin_diag.stable_ptr.lookup(db.upcast())),
@@ -506,11 +506,13 @@ impl Fixer {
         format!("{option_var_name}.is_some()")
     }
 
-    /// Removes all spaces from the given text.
+    /// Removes invisible characters from the given text.
     pub fn fix_whitespace_issues(&self, db: &dyn SyntaxGroup, node: SyntaxNode) -> String {
-    let text = node.get_text(db);
-    text.replace(" ", "")
-    
+        let text = node.get_text(db);
+        let invisible_chars = ['\u{200B}', '\u{00AD}', '\u{200C}', '\u{200D}', '\u{202C}', '\u{FEFF}'];
+
+
+        invisible_chars.iter().fold(text, |acc, &ch| acc.replace(ch, ""))
     }
 
 

--- a/crates/cairo-lint-core/src/fix.rs
+++ b/crates/cairo-lint-core/src/fix.rs
@@ -5,7 +5,7 @@ use cairo_lang_semantic::diagnostic::SemanticDiagnosticKind;
 use cairo_lang_semantic::SemanticDiagnostic;
 use cairo_lang_syntax::node::ast::{
     BlockOrIf, Condition, ElseClause, Expr, ExprBinary, ExprIf, ExprLoop, ExprMatch, OptionElseClause,
-    OptionPatternEnumInnerPattern, Pattern, Statement,
+    OptionPatternEnumInnerPattern, Pattern, Statement
 };
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::{SyntaxNode, TypedSyntaxNode};
@@ -506,10 +506,12 @@ impl Fixer {
         format!("{option_var_name}.is_some()")
     }
 
-      /// Removes all spaces from the given text.
-      pub fn fix_whitespace_issues(&self, db: &dyn SyntaxGroup, node: SyntaxNode) -> String {
-        let text = node.get_text(db);
-         text.replace(" ", "")
+    /// Removes all spaces from the given text.
+    pub fn fix_whitespace_issues(&self, db: &dyn SyntaxGroup, node: SyntaxNode) -> String {
+    let text = node.get_text(db);
+    text.replace(" ", "")
     
     }
+
+
 }

--- a/crates/cairo-lint-core/src/fix.rs
+++ b/crates/cairo-lint-core/src/fix.rs
@@ -169,6 +169,9 @@ impl Fixer {
             CairoLintKind::DoubleComparison => {
                 self.fix_double_comparison(db.upcast(), plugin_diag.stable_ptr.lookup(db.upcast()))
             }
+            CairoLintKind::InvisibleCharacters => {
+                self.fix_whitespace_issues(db, plugin_diag.stable_ptr.lookup(db.upcast()))
+            }
             CairoLintKind::EquatableIfLet => self.fix_equatable_if_let(db, plugin_diag.stable_ptr.lookup(db.upcast())),
             CairoLintKind::BreakUnit => self.fix_break_unit(db, plugin_diag.stable_ptr.lookup(db.upcast())),
             CairoLintKind::BoolComparison => self.fix_bool_comparison(
@@ -501,5 +504,12 @@ impl Fixer {
         };
 
         format!("{option_var_name}.is_some()")
+    }
+
+      /// Removes all spaces from the given text.
+      pub fn fix_whitespace_issues(&self, db: &dyn SyntaxGroup, node: SyntaxNode) -> String {
+        let text = node.get_text(db);
+         text.replace(" ", "")
+    
     }
 }

--- a/crates/cairo-lint-core/src/lints/invisible_characters.rs
+++ b/crates/cairo-lint-core/src/lints/invisible_characters.rs
@@ -1,0 +1,28 @@
+use cairo_lang_defs::plugin::PluginDiagnostic;
+use cairo_lang_diagnostics::Severity;
+use cairo_lang_syntax::node::ast::Expr;
+use cairo_lang_syntax::node::db::SyntaxGroup;
+use cairo_lang_syntax::node::{TypedStablePtr, TypedSyntaxNode};
+
+pub const WHITESPACE_DETECTED: &str = "Whitespace detected.";
+pub const INVISIBLE_CHARACTER_DETECTED: &str = "Invisible character detected.";
+
+pub fn check_invisible_characters(expr: &Expr, db: &dyn SyntaxGroup, diagnostics: &mut Vec<PluginDiagnostic>) {
+    let syntax_node = expr.as_syntax_node();
+    let text = syntax_node.get_text(db);
+    if text.chars().any(char::is_whitespace) {
+        diagnostics.push(PluginDiagnostic {
+            stable_ptr: expr.stable_ptr().untyped(),
+            message: WHITESPACE_DETECTED.to_string(),
+            severity: Severity::Warning,
+        });
+    }
+    let invisible_chars = ['\u{200B}', '\u{00AD}', '\u{200C}', '\u{200D}', '\u{202C}', '\u{FEFF}'];
+    if text.chars().any(|c| invisible_chars.contains(&c)) {
+        diagnostics.push(PluginDiagnostic {
+            stable_ptr: expr.stable_ptr().untyped(),
+            message: INVISIBLE_CHARACTER_DETECTED.to_string(),
+            severity: Severity::Error,
+        });
+    }
+}

--- a/crates/cairo-lint-core/src/lints/invisible_characters.rs
+++ b/crates/cairo-lint-core/src/lints/invisible_characters.rs
@@ -4,19 +4,12 @@ use cairo_lang_syntax::node::ast::Expr;
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::{TypedStablePtr, TypedSyntaxNode};
 
-pub const WHITESPACE_DETECTED: &str = "Whitespace detected.";
 pub const INVISIBLE_CHARACTER_DETECTED: &str = "Invisible character detected.";
 
 pub fn check_invisible_characters(expr: &Expr, db: &dyn SyntaxGroup, diagnostics: &mut Vec<PluginDiagnostic>) {
     let syntax_node = expr.as_syntax_node();
     let text = syntax_node.get_text(db);
-    if text.chars().any(char::is_whitespace) {
-        diagnostics.push(PluginDiagnostic {
-            stable_ptr: expr.stable_ptr().untyped(),
-            message: WHITESPACE_DETECTED.to_string(),
-            severity: Severity::Warning,
-        });
-    }
+   
     let invisible_chars = ['\u{200B}', '\u{00AD}', '\u{200C}', '\u{200D}', '\u{202C}', '\u{FEFF}'];
     if text.chars().any(|c| invisible_chars.contains(&c)) {
         diagnostics.push(PluginDiagnostic {

--- a/crates/cairo-lint-core/src/lints/invisible_characters.rs
+++ b/crates/cairo-lint-core/src/lints/invisible_characters.rs
@@ -6,7 +6,11 @@ use cairo_lang_syntax::node::{TypedStablePtr, TypedSyntaxNode};
 
 pub const INVISIBLE_CHARACTER_DETECTED: &str = "Invisible character detected.";
 
-pub fn check_invisible_characters(expr: &Expr, db: &dyn SyntaxGroup, diagnostics: &mut Vec<PluginDiagnostic>) {
+pub fn check_invisible_characters(
+    expr: &Expr, 
+    db: &dyn SyntaxGroup, 
+    diagnostics: &mut Vec<PluginDiagnostic>
+) {
     let syntax_node = expr.as_syntax_node();
     let text = syntax_node.get_text(db);
    

--- a/crates/cairo-lint-core/src/lints/mod.rs
+++ b/crates/cairo-lint-core/src/lints/mod.rs
@@ -11,3 +11,4 @@ pub mod manual;
 pub mod panic;
 pub mod single_match;
 pub mod invisible_characters;
+

--- a/crates/cairo-lint-core/src/lints/mod.rs
+++ b/crates/cairo-lint-core/src/lints/mod.rs
@@ -10,3 +10,4 @@ pub mod loops;
 pub mod manual;
 pub mod panic;
 pub mod single_match;
+pub mod invisible_characters;

--- a/crates/cairo-lint-core/src/plugin.rs
+++ b/crates/cairo-lint-core/src/plugin.rs
@@ -144,12 +144,14 @@ impl AnalyzerPlugin for CairoLint {
                             &mut diags,
                         );
                     }
-                    SyntaxKind::ExprInlineMacro => {invisible_characters::check_invisible_characters(
-                        &AstExpr::from_syntax_node(db.upcast(), node),
-                        db.upcast(),
-                            &mut diags,
+                    SyntaxKind::ExprInlineMacro => {
+                        invisible_characters::check_invisible_characters(
+                            &AstExpr::from_syntax_node(db.upcast(), node),  
+                            db.upcast(),                                    
+                            &mut diags                                      
                         );
                     }
+
                     _ => continue,
                 }
             }

--- a/crates/cairo-lint-core/src/plugin.rs
+++ b/crates/cairo-lint-core/src/plugin.rs
@@ -62,7 +62,6 @@ pub fn diagnostic_kind_from_message(message: &str) -> CairoLintKind {
         erasing_op::ERASING_OPERATION => CairoLintKind::ErasingOperation,
         manual_ok_or::MANUAL_OK_OR => CairoLintKind::ManualOkOr,
         manual_is_some::MANUAL_IS_SOME => CairoLintKind::ManualIsSome,
-      
         invisible_characters::INVISIBLE_CHARACTER_DETECTED => CairoLintKind::InvisibleCharacters,
         _ => CairoLintKind::Unknown,
     }

--- a/crates/cairo-lint-core/src/plugin.rs
+++ b/crates/cairo-lint-core/src/plugin.rs
@@ -62,7 +62,7 @@ pub fn diagnostic_kind_from_message(message: &str) -> CairoLintKind {
         erasing_op::ERASING_OPERATION => CairoLintKind::ErasingOperation,
         manual_ok_or::MANUAL_OK_OR => CairoLintKind::ManualOkOr,
         manual_is_some::MANUAL_IS_SOME => CairoLintKind::ManualIsSome,
-        invisible_characters::WHITESPACE_DETECTED => CairoLintKind::InvisibleCharacters,
+      
         invisible_characters::INVISIBLE_CHARACTER_DETECTED => CairoLintKind::InvisibleCharacters,
         _ => CairoLintKind::Unknown,
     }

--- a/crates/cairo-lint-core/src/plugin.rs
+++ b/crates/cairo-lint-core/src/plugin.rs
@@ -11,7 +11,7 @@ use crate::lints::ifs::*;
 use crate::lints::manual::*;
 use crate::lints::{
     bool_comparison, breaks, double_comparison, double_parens, duplicate_underscore_args, erasing_op, loop_for_while,
-    loops, panic, single_match,
+    loops, panic, single_match, invisible_characters
 };
 
 pub fn cairo_lint_plugin_suite() -> PluginSuite {
@@ -40,6 +40,7 @@ pub enum CairoLintKind {
     ErasingOperation,
     ManualOkOr,
     ManualIsSome,
+    InvisibleCharacters,
 }
 
 pub fn diagnostic_kind_from_message(message: &str) -> CairoLintKind {
@@ -61,6 +62,8 @@ pub fn diagnostic_kind_from_message(message: &str) -> CairoLintKind {
         erasing_op::ERASING_OPERATION => CairoLintKind::ErasingOperation,
         manual_ok_or::MANUAL_OK_OR => CairoLintKind::ManualOkOr,
         manual_is_some::MANUAL_IS_SOME => CairoLintKind::ManualIsSome,
+        invisible_characters::WHITESPACE_DETECTED => CairoLintKind::InvisibleCharacters,
+        invisible_characters::INVISIBLE_CHARACTER_DETECTED => CairoLintKind::InvisibleCharacters,
         _ => CairoLintKind::Unknown,
     }
 }
@@ -139,6 +142,12 @@ impl AnalyzerPlugin for CairoLint {
                         manual_is_some::check_manual_is_some(
                             db.upcast(),
                             &ExprMatch::from_syntax_node(db.upcast(), node),
+                            &mut diags,
+                        );
+                    }
+                    SyntaxKind::ExprInlineMacro => {invisible_characters::check_invisible_characters(
+                        &AstExpr::from_syntax_node(db.upcast(), node),
+                        db.upcast(),
                             &mut diags,
                         );
                     }

--- a/crates/cairo-lint-core/tests/test_files/invisible_characters/invisible_characters
+++ b/crates/cairo-lint-core/tests/test_files/invisible_characters/invisible_characters
@@ -1,0 +1,129 @@
+//! > loop match pop front with spaces
+
+//! > cairo_code
+fn main() {
+    let mut a: Span<u32> = array![ 1,  2,  3,  4,  5 ].span();  
+    loop {
+        match a.pop_front() {
+            Option::Some(val) => println!("{val}"),
+            Option::None => { 
+               
+                break;
+            },
+        }
+    }
+}
+
+//! > diagnostics
+warning: Plugin diagnostic: you seem to be trying to use `loop` for iterating over a span. Consider using `for in`
+  --> lib.cairo:4:5
+   |
+ 4 |       loop {
+   |  _____-
+ 5 | |         match a.pop_front() {
+...  |
+11 | |         }
+12 | |     }
+   | |_____-
+   |
+warning: Plugin diagnostic: Whitespace detected.
+ --> lib.cairo:2:28
+  |
+2 |     let mut a: Span<u32> = array![ 1,  2,  3,  4,  5 ].span();  
+  |                            ---------------------------
+  |
+
+//! > fixed
+fn main() {
+    let mut a: Span<u32> = array![1,2,3,4,5].span();  
+
+    for val in a {
+        println!("{val}")
+    };
+}
+
+//! > ==========================================================================
+
+//! > loop match pop front with spaces in none
+
+//! > cairo_code
+fn main() {
+    let mut a: Span<u32> = array![ 1, 2, 3, 4, 5 ].span();
+    loop {
+        match a.pop_front() {
+            Option::Some(val) => println!("{val}"),
+            Option::None => { 
+                println!("Finished looping  ");  
+                break;
+            },
+        }
+    }
+}
+
+//! > diagnostics
+warning: Plugin diagnostic: Whitespace detected.
+ --> lib.cairo:2:28
+  |
+2 |     let mut a: Span<u32> = array![ 1, 2, 3, 4, 5 ].span();
+  |                            -----------------------
+  |
+warning: Plugin diagnostic: Whitespace detected.
+  --> lib.cairo:12:17
+   |
+12 |                 println!("Finished looping  ");  
+   |                 ------------------------------
+   |
+
+//! > fixed
+fn main() {
+    let mut a: Span<u32> = array![1,2,3,4,5].span();
+    loop {
+        match a.pop_front() {
+            Option::Some(val) => println!("{val}"),
+            Option::None => { 
+println!("Finishedlooping");  
+                break;
+            },
+        }
+    }
+}
+
+//! > ==========================================================================
+
+//! > simple loop match pop front with comment and spaces
+
+//! > cairo_code
+fn main() {
+    let mut a: Span<u32> = array![ 1,  2,  3,  4,  5 ].span();  // Extra spaces between elements
+    loop {
+        match a.pop_front() {
+            Option::Some(val) => println!("{val}"),
+            Option::None => { 
+                // Comment with space
+                break;
+            },
+        }
+    }
+}
+
+//! > diagnostics
+warning: Plugin diagnostic: Whitespace detected.
+ --> lib.cairo:2:28
+  |
+2 |     let mut a: Span<u32> = array![ 1,  2,  3,  4,  5 ].span();  // Extra spaces between elements
+  |                            ---------------------------
+  |
+
+//! > fixed
+fn main() {
+    let mut a: Span<u32> = array![1,2,3,4,5].span();  // Extra spaces between elements
+    loop {
+        match a.pop_front() {
+            Option::Some(val) => println!("{val}"),
+            Option::None => { 
+                // Comment with space
+                break;
+            },
+        }
+    }
+}

--- a/crates/cairo-lint-core/tests/test_files/invisible_characters/invisible_characters
+++ b/crates/cairo-lint-core/tests/test_files/invisible_characters/invisible_characters
@@ -1,1565 +1,165 @@
-//! > loop check invisible characters
+//! > detect byte order mark
 
 //! > cairo_code
 fn main() {
-    let text = "Hello\u{200B}World\u{2060}!";
-    let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
-
-    let mut index = 0;
-    let chars: Vec<char> = text.chars().collect();
-
-    loop {
-        match chars.get(index) {
-            Some(&ch) => {
-                if invisible_chars.contains(&ch) {
-                    println!("Invisible character detected at index {}: {}", index, ch.escape_unicode());
-                }
-                index += 1;
-            },
-            None => {
-                break;
-            },
-        }
-    }
+   let text = "\u{FEFF}HelloWorld";
 }
 
 //! > diagnostics
-error: Type not found.
-  --> lib.cairo:10:16
-   |
-10 |     let chars: Vec<char> = text.chars().collect();
-   |                ^^^
-   |
-error: Method `chars` not found on type `?0`. Did you import the correct trait and impl?
-  --> lib.cairo:10:33
-   |
-10 |     let chars: Vec<char> = text.chars().collect();
-   |                                 ^^^^^
-   |
-error: Method `collect` not found on type `<missing>`. Did you import the correct trait and impl?
-  --> lib.cairo:10:41
-   |
-10 |     let chars: Vec<char> = text.chars().collect();
-   |                                         ^^^^^^^
-   |
-error: Ambiguous method call. More than one applicable trait function with a suitable self type was found: ArrayTrait::get and SpanTrait::get. Consider adding type annotations or explicitly refer to the impl function.
-  --> lib.cairo:16:21
-   |
-16 |         match chars.get(index) {
-   |                     ^^^
-   |
-error: Identifier not found.
-  --> lib.cairo:18:13
-   |
-18 |             Some(&ch) => {
-   |             ^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:18:13
-   |
-18 |             Some(&ch) => {
-   |             ^^^^^
-   |
-error: Unsupported feature.
-  --> lib.cairo:18:21
-   |
-18 |             Some(&ch) => {
-   |                     ^
-   |
 warning: Unused variable. Consider ignoring by prefixing with `_`.
-  --> lib.cairo:18:19
-   |
-18 |             Some(&ch) => {
-   |                   --
-   |
-error: Identifier not found.
-  --> lib.cairo:20:36
-   |
-20 |                 if invisible_chars.contains(&ch) {
-   |                                    ^^^^^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:20:20
-   |
-20 |                 if invisible_chars.contains(&ch) {
-   |                    ^^^^^^^^^^^^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:20:36
-   |
-20 |                 if invisible_chars.contains(&ch) {
-   |                                    ^^^^^^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:20:46
-   |
-20 |                 if invisible_chars.contains(&ch) {
-   |                                              ^^
-   |
-error: Unsupported feature.
-  --> lib.cairo:20:48
-   |
-20 |                 if invisible_chars.contains(&ch) {
-   |                                                ^
-   |
-warning: Unused variable. Consider ignoring by prefixing with `_`.
-  --> lib.cairo:20:20
-   |
-20 |                 if invisible_chars.contains(&ch) {
-   |                    ---------------
-   |
-warning: Unused variable. Consider ignoring by prefixing with `_`.
-  --> lib.cairo:20:46
-   |
-20 |                 if invisible_chars.contains(&ch) {
-   |                                              --
-   |
-error: Unexpected type for tuple pattern. "<missing>" is not a tuple.
-  --> lib.cairo:22:29
-   |
-22 |                     println!("Invisible character detected at index {}: {}", index, ch.escape_unicode());
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:22:29
-   |
-22 |                     println!("Invisible character detected at index {}: {}", index, ch.escape_unicode());
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-error: Unsupported feature.
-  --> lib.cairo:22:105
-   |
-22 |                     println!("Invisible character detected at index {}: {}", index, ch.escape_unicode());
-   |                                                                                                         ^
-   |
-warning: Unused variable. Consider ignoring by prefixing with `_`.
-  --> lib.cairo:22:21
-   |
-22 |                     println!("Invisible character detected at index {}: {}", index, ch.escape_unicode());
-   |                     -------
-   |
-error: Missing semicolon
-  --> lib.cairo:28:14
-   |
-28 |             },
-   |              ^
-   |
-error: Identifier not found.
-  --> lib.cairo:30:13
-   |
-30 |             None => {
-   |             ^^^^
-   |
-error: Missing semicolon
-  --> lib.cairo:30:17
-   |
-30 |             None => {
-   |                 ^
-   |
-error: `break` only allowed inside a `loop`.
-  --> lib.cairo:32:17
-   |
-32 |                 break;
-   |                 ^^^^^^
-   |
-warning: Unused variable. Consider ignoring by prefixing with `_`.
- --> lib.cairo:4:9
+ --> lib.cairo:2:8
   |
-4 |     let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
-  |         ---------------
+2 |    let text = "\u{FEFF}HelloWorld";
+  |        ----
+  |
+error: Type annotations needed. Failed to infer ?0.
+ --> lib.cairo:2:15
+  |
+2 |    let text = "\u{FEFF}HelloWorld";
+  |               ^^^^^^^^^^^^^^^^^^^^
   |
 
 //! > fixed
 fn main() {
-    let text = "Hello\u{200B}World\u{2060}!";
-    let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
-
-    let mut index = 0;
-    let chars: Vec<char> = text.chars().collect();
-
-    loop {
-        match chars.get(index) {
-            Some(&ch) => {
-                if invisible_chars.contains(&ch) {
-                    println!("Invisible character detected at index {}: {}", index, ch.escape_unicode());
-                }
-                index += 1;
-            },
-            None => {
-                break;
-            },
-        }
-    }
+   let text = "\u{FEFF}HelloWorld";
 }
 
 //! > ==========================================================================
 
-//! > loop check invisible characters in URL
+//! > detect paragraph separator
 
 //! > cairo_code
 fn main() {
-   let text = "https://example\u{200B}.com";
-   let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
-
-   let mut index = 0;
-   let chars: Vec<char> = text.chars().collect();
-
-   loop {
-       match chars.get(index) {
-           Some(&ch) => {
-               if invisible_chars.contains(&ch) {
-                   println!("Invisible character detected at index {} in URL.", index);
-               }
-               index += 1;
-           },
-           None => {
-               break;
-           },
-       }
-   }
+   let text = "Paragraph\u{2029}Separator";
 }
 
 //! > diagnostics
-error: Type not found.
-  --> lib.cairo:10:15
-   |
-10 |    let chars: Vec<char> = text.chars().collect();
-   |               ^^^
-   |
-error: Method `chars` not found on type `?0`. Did you import the correct trait and impl?
-  --> lib.cairo:10:32
-   |
-10 |    let chars: Vec<char> = text.chars().collect();
-   |                                ^^^^^
-   |
-error: Method `collect` not found on type `<missing>`. Did you import the correct trait and impl?
-  --> lib.cairo:10:40
-   |
-10 |    let chars: Vec<char> = text.chars().collect();
-   |                                        ^^^^^^^
-   |
-error: Ambiguous method call. More than one applicable trait function with a suitable self type was found: ArrayTrait::get and SpanTrait::get. Consider adding type annotations or explicitly refer to the impl function.
-  --> lib.cairo:16:20
-   |
-16 |        match chars.get(index) {
-   |                    ^^^
-   |
-error: Identifier not found.
-  --> lib.cairo:18:12
-   |
-18 |            Some(&ch) => {
-   |            ^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:18:12
-   |
-18 |            Some(&ch) => {
-   |            ^^^^^
-   |
-error: Unsupported feature.
-  --> lib.cairo:18:20
-   |
-18 |            Some(&ch) => {
-   |                    ^
-   |
 warning: Unused variable. Consider ignoring by prefixing with `_`.
-  --> lib.cairo:18:18
-   |
-18 |            Some(&ch) => {
-   |                  --
-   |
-error: Identifier not found.
-  --> lib.cairo:20:35
-   |
-20 |                if invisible_chars.contains(&ch) {
-   |                                   ^^^^^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:20:19
-   |
-20 |                if invisible_chars.contains(&ch) {
-   |                   ^^^^^^^^^^^^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:20:35
-   |
-20 |                if invisible_chars.contains(&ch) {
-   |                                   ^^^^^^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:20:45
-   |
-20 |                if invisible_chars.contains(&ch) {
-   |                                             ^^
-   |
-error: Unsupported feature.
-  --> lib.cairo:20:47
-   |
-20 |                if invisible_chars.contains(&ch) {
-   |                                               ^
-   |
-warning: Unused variable. Consider ignoring by prefixing with `_`.
-  --> lib.cairo:20:19
-   |
-20 |                if invisible_chars.contains(&ch) {
-   |                   ---------------
-   |
-warning: Unused variable. Consider ignoring by prefixing with `_`.
-  --> lib.cairo:20:45
-   |
-20 |                if invisible_chars.contains(&ch) {
-   |                                             --
-   |
-error: Unexpected type for tuple pattern. "<missing>" is not a tuple.
-  --> lib.cairo:22:28
-   |
-22 |                    println!("Invisible character detected at index {} in URL.", index);
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:22:28
-   |
-22 |                    println!("Invisible character detected at index {} in URL.", index);
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-error: Unsupported feature.
-  --> lib.cairo:22:87
-   |
-22 |                    println!("Invisible character detected at index {} in URL.", index);
-   |                                                                                       ^
-   |
-warning: Unused variable. Consider ignoring by prefixing with `_`.
-  --> lib.cairo:22:20
-   |
-22 |                    println!("Invisible character detected at index {} in URL.", index);
-   |                    -------
-   |
-error: Missing semicolon
-  --> lib.cairo:28:13
-   |
-28 |            },
-   |             ^
-   |
-error: Identifier not found.
-  --> lib.cairo:30:12
-   |
-30 |            None => {
-   |            ^^^^
-   |
-error: Missing semicolon
-  --> lib.cairo:30:16
-   |
-30 |            None => {
-   |                ^
-   |
-error: `break` only allowed inside a `loop`.
-  --> lib.cairo:32:16
-   |
-32 |                break;
-   |                ^^^^^^
-   |
-warning: Unused variable. Consider ignoring by prefixing with `_`.
- --> lib.cairo:4:8
+ --> lib.cairo:2:8
   |
-4 |    let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
-  |        ---------------
+2 |    let text = "Paragraph\u{2029}Separator";
+  |        ----
+  |
+error: Type annotations needed. Failed to infer ?0.
+ --> lib.cairo:2:15
+  |
+2 |    let text = "Paragraph\u{2029}Separator";
+  |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
 
 //! > fixed
 fn main() {
-   let text = "https://example\u{200B}.com";
-   let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
-
-   let mut index = 0;
-   let chars: Vec<char> = text.chars().collect();
-
-   loop {
-       match chars.get(index) {
-           Some(&ch) => {
-               if invisible_chars.contains(&ch) {
-                   println!("Invisible character detected at index {} in URL.", index);
-               }
-               index += 1;
-           },
-           None => {
-               break;
-           },
-       }
-   }
+   let text = "Paragraph\u{2029}Separator";
 }
 
 //! > ==========================================================================
 
-//! > loop check invisible characters in comments
+//! > detect zero-width joiner
 
 //! > cairo_code
 fn main() {
-    let text = "HelloWorld! // Comment with invisible\u{200B}character";
-    let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
-
-    let mut index = 0;
-    let chars: Vec<char> = text.chars().collect();
-
-    loop {
-        match chars.get(index) {
-            Some(&ch) => {
-                if invisible_chars.contains(&ch) {
-                    println!("Invisible character detected at index {}: {}", index, ch.escape_unicode());
-                }
-                index += 1;
-            },
-            None => {
-                break;
-            },
-        }
-    }
+   let text = "Joiner\u{200D}Here";
 }
 
 //! > diagnostics
-error: Type not found.
-  --> lib.cairo:10:16
-   |
-10 |     let chars: Vec<char> = text.chars().collect();
-   |                ^^^
-   |
-error: Method `chars` not found on type `?0`. Did you import the correct trait and impl?
-  --> lib.cairo:10:33
-   |
-10 |     let chars: Vec<char> = text.chars().collect();
-   |                                 ^^^^^
-   |
-error: Method `collect` not found on type `<missing>`. Did you import the correct trait and impl?
-  --> lib.cairo:10:41
-   |
-10 |     let chars: Vec<char> = text.chars().collect();
-   |                                         ^^^^^^^
-   |
-error: Ambiguous method call. More than one applicable trait function with a suitable self type was found: ArrayTrait::get and SpanTrait::get. Consider adding type annotations or explicitly refer to the impl function.
-  --> lib.cairo:16:21
-   |
-16 |         match chars.get(index) {
-   |                     ^^^
-   |
-error: Identifier not found.
-  --> lib.cairo:18:13
-   |
-18 |             Some(&ch) => {
-   |             ^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:18:13
-   |
-18 |             Some(&ch) => {
-   |             ^^^^^
-   |
-error: Unsupported feature.
-  --> lib.cairo:18:21
-   |
-18 |             Some(&ch) => {
-   |                     ^
-   |
 warning: Unused variable. Consider ignoring by prefixing with `_`.
-  --> lib.cairo:18:19
-   |
-18 |             Some(&ch) => {
-   |                   --
-   |
-error: Identifier not found.
-  --> lib.cairo:20:36
-   |
-20 |                 if invisible_chars.contains(&ch) {
-   |                                    ^^^^^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:20:20
-   |
-20 |                 if invisible_chars.contains(&ch) {
-   |                    ^^^^^^^^^^^^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:20:36
-   |
-20 |                 if invisible_chars.contains(&ch) {
-   |                                    ^^^^^^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:20:46
-   |
-20 |                 if invisible_chars.contains(&ch) {
-   |                                              ^^
-   |
-error: Unsupported feature.
-  --> lib.cairo:20:48
-   |
-20 |                 if invisible_chars.contains(&ch) {
-   |                                                ^
-   |
-warning: Unused variable. Consider ignoring by prefixing with `_`.
-  --> lib.cairo:20:20
-   |
-20 |                 if invisible_chars.contains(&ch) {
-   |                    ---------------
-   |
-warning: Unused variable. Consider ignoring by prefixing with `_`.
-  --> lib.cairo:20:46
-   |
-20 |                 if invisible_chars.contains(&ch) {
-   |                                              --
-   |
-error: Unexpected type for tuple pattern. "<missing>" is not a tuple.
-  --> lib.cairo:22:29
-   |
-22 |                     println!("Invisible character detected at index {}: {}", index, ch.escape_unicode());
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:22:29
-   |
-22 |                     println!("Invisible character detected at index {}: {}", index, ch.escape_unicode());
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-error: Unsupported feature.
-  --> lib.cairo:22:105
-   |
-22 |                     println!("Invisible character detected at index {}: {}", index, ch.escape_unicode());
-   |                                                                                                         ^
-   |
-warning: Unused variable. Consider ignoring by prefixing with `_`.
-  --> lib.cairo:22:21
-   |
-22 |                     println!("Invisible character detected at index {}: {}", index, ch.escape_unicode());
-   |                     -------
-   |
-error: Missing semicolon
-  --> lib.cairo:28:14
-   |
-28 |             },
-   |              ^
-   |
-error: Identifier not found.
-  --> lib.cairo:30:13
-   |
-30 |             None => {
-   |             ^^^^
-   |
-error: Missing semicolon
-  --> lib.cairo:30:17
-   |
-30 |             None => {
-   |                 ^
-   |
-error: `break` only allowed inside a `loop`.
-  --> lib.cairo:32:17
-   |
-32 |                 break;
-   |                 ^^^^^^
-   |
-warning: Unused variable. Consider ignoring by prefixing with `_`.
- --> lib.cairo:4:9
+ --> lib.cairo:2:8
   |
-4 |     let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
-  |         ---------------
+2 |    let text = "Joiner\u{200D}Here";
+  |        ----
+  |
+error: Type annotations needed. Failed to infer ?0.
+ --> lib.cairo:2:15
+  |
+2 |    let text = "Joiner\u{200D}Here";
+  |               ^^^^^^^^^^^^^^^^^^^^
   |
 
 //! > fixed
 fn main() {
-    let text = "HelloWorld! // Comment with invisible\u{200B}character";
-    let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
-
-    let mut index = 0;
-    let chars: Vec<char> = text.chars().collect();
-
-    loop {
-        match chars.get(index) {
-            Some(&ch) => {
-                if invisible_chars.contains(&ch) {
-                    println!("Invisible character detected at index {}: {}", index, ch.escape_unicode());
-                }
-                index += 1;
-            },
-            None => {
-                break;
-            },
-        }
-    }
+   let text = "Joiner\u{200D}Here";
 }
 
 //! > ==========================================================================
 
-//! > loop check invisible characters in config
+//! > detect zero-width non-joiner
 
 //! > cairo_code
 fn main() {
-   let config = "setting\u{200B}=true";
-   let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
-
-   let mut index = 0;
-   let chars: Vec<char> = config.chars().collect();
-
-   loop {
-       match chars.get(index) {
-           Some(&ch) => {
-               if invisible_chars.contains(&ch) {
-                   println!("Invisible character detected at index {} in configuration.", index);
-               }
-               index += 1;
-           },
-           None => {
-               break;
-           },
-       }
-   }
+   let text = "NonJoiner\u{200C}Here";
 }
 
 //! > diagnostics
-error: Type not found.
-  --> lib.cairo:10:15
-   |
-10 |    let chars: Vec<char> = config.chars().collect();
-   |               ^^^
-   |
-error: Method `chars` not found on type `?0`. Did you import the correct trait and impl?
-  --> lib.cairo:10:34
-   |
-10 |    let chars: Vec<char> = config.chars().collect();
-   |                                  ^^^^^
-   |
-error: Method `collect` not found on type `<missing>`. Did you import the correct trait and impl?
-  --> lib.cairo:10:42
-   |
-10 |    let chars: Vec<char> = config.chars().collect();
-   |                                          ^^^^^^^
-   |
-error: Ambiguous method call. More than one applicable trait function with a suitable self type was found: ArrayTrait::get and SpanTrait::get. Consider adding type annotations or explicitly refer to the impl function.
-  --> lib.cairo:16:20
-   |
-16 |        match chars.get(index) {
-   |                    ^^^
-   |
-error: Identifier not found.
-  --> lib.cairo:18:12
-   |
-18 |            Some(&ch) => {
-   |            ^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:18:12
-   |
-18 |            Some(&ch) => {
-   |            ^^^^^
-   |
-error: Unsupported feature.
-  --> lib.cairo:18:20
-   |
-18 |            Some(&ch) => {
-   |                    ^
-   |
 warning: Unused variable. Consider ignoring by prefixing with `_`.
-  --> lib.cairo:18:18
-   |
-18 |            Some(&ch) => {
-   |                  --
-   |
-error: Identifier not found.
-  --> lib.cairo:20:35
-   |
-20 |                if invisible_chars.contains(&ch) {
-   |                                   ^^^^^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:20:19
-   |
-20 |                if invisible_chars.contains(&ch) {
-   |                   ^^^^^^^^^^^^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:20:35
-   |
-20 |                if invisible_chars.contains(&ch) {
-   |                                   ^^^^^^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:20:45
-   |
-20 |                if invisible_chars.contains(&ch) {
-   |                                             ^^
-   |
-error: Unsupported feature.
-  --> lib.cairo:20:47
-   |
-20 |                if invisible_chars.contains(&ch) {
-   |                                               ^
-   |
-warning: Unused variable. Consider ignoring by prefixing with `_`.
-  --> lib.cairo:20:19
-   |
-20 |                if invisible_chars.contains(&ch) {
-   |                   ---------------
-   |
-warning: Unused variable. Consider ignoring by prefixing with `_`.
-  --> lib.cairo:20:45
-   |
-20 |                if invisible_chars.contains(&ch) {
-   |                                             --
-   |
-error: Unexpected type for tuple pattern. "<missing>" is not a tuple.
-  --> lib.cairo:22:28
-   |
-22 |                    println!("Invisible character detected at index {} in configuration.", index);
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:22:28
-   |
-22 |                    println!("Invisible character detected at index {} in configuration.", index);
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-error: Unsupported feature.
-  --> lib.cairo:22:97
-   |
-22 |                    println!("Invisible character detected at index {} in configuration.", index);
-   |                                                                                                 ^
-   |
-warning: Unused variable. Consider ignoring by prefixing with `_`.
-  --> lib.cairo:22:20
-   |
-22 |                    println!("Invisible character detected at index {} in configuration.", index);
-   |                    -------
-   |
-error: Missing semicolon
-  --> lib.cairo:28:13
-   |
-28 |            },
-   |             ^
-   |
-error: Identifier not found.
-  --> lib.cairo:30:12
-   |
-30 |            None => {
-   |            ^^^^
-   |
-error: Missing semicolon
-  --> lib.cairo:30:16
-   |
-30 |            None => {
-   |                ^
-   |
-error: `break` only allowed inside a `loop`.
-  --> lib.cairo:32:16
-   |
-32 |                break;
-   |                ^^^^^^
-   |
-warning: Unused variable. Consider ignoring by prefixing with `_`.
- --> lib.cairo:4:8
+ --> lib.cairo:2:8
   |
-4 |    let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
-  |        ---------------
+2 |    let text = "NonJoiner\u{200C}Here";
+  |        ----
+  |
+error: Type annotations needed. Failed to infer ?0.
+ --> lib.cairo:2:15
+  |
+2 |    let text = "NonJoiner\u{200C}Here";
+  |               ^^^^^^^^^^^^^^^^^^^^^^^
   |
 
 //! > fixed
 fn main() {
-   let config = "setting\u{200B}=true";
-   let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
-
-   let mut index = 0;
-   let chars: Vec<char> = config.chars().collect();
-
-   loop {
-       match chars.get(index) {
-           Some(&ch) => {
-               if invisible_chars.contains(&ch) {
-                   println!("Invisible character detected at index {} in configuration.", index);
-               }
-               index += 1;
-           },
-           None => {
-               break;
-           },
-       }
-   }
+   let text = "NonJoiner\u{200C}Here";
 }
 
 //! > ==========================================================================
 
-//! > loop check invisible characters in filename
+//! > detect zero-width space
 
 //! > cairo_code
 fn main() {
-   let filename = "file\u{200B}name.txt";
-   let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
-
-   let mut index = 0;
-   let chars: Vec<char> = filename.chars().collect();
-
-   loop {
-       match chars.get(index) {
-           Some(&ch) => {
-               if invisible_chars.contains(&ch) {
-                   println!("Invisible character detected at index {} in filename.", index);
-               }
-               index += 1;
-           },
-           None => {
-               break;
-           },
-       }
-   }
+   let text = "Hello\u{200B}World!";
 }
 
 //! > diagnostics
-error: Type not found.
-  --> lib.cairo:10:15
-   |
-10 |    let chars: Vec<char> = filename.chars().collect();
-   |               ^^^
-   |
-error: Method `chars` not found on type `?0`. Did you import the correct trait and impl?
-  --> lib.cairo:10:36
-   |
-10 |    let chars: Vec<char> = filename.chars().collect();
-   |                                    ^^^^^
-   |
-error: Method `collect` not found on type `<missing>`. Did you import the correct trait and impl?
-  --> lib.cairo:10:44
-   |
-10 |    let chars: Vec<char> = filename.chars().collect();
-   |                                            ^^^^^^^
-   |
-error: Ambiguous method call. More than one applicable trait function with a suitable self type was found: ArrayTrait::get and SpanTrait::get. Consider adding type annotations or explicitly refer to the impl function.
-  --> lib.cairo:16:20
-   |
-16 |        match chars.get(index) {
-   |                    ^^^
-   |
-error: Identifier not found.
-  --> lib.cairo:18:12
-   |
-18 |            Some(&ch) => {
-   |            ^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:18:12
-   |
-18 |            Some(&ch) => {
-   |            ^^^^^
-   |
-error: Unsupported feature.
-  --> lib.cairo:18:20
-   |
-18 |            Some(&ch) => {
-   |                    ^
-   |
 warning: Unused variable. Consider ignoring by prefixing with `_`.
-  --> lib.cairo:18:18
-   |
-18 |            Some(&ch) => {
-   |                  --
-   |
-error: Identifier not found.
-  --> lib.cairo:20:35
-   |
-20 |                if invisible_chars.contains(&ch) {
-   |                                   ^^^^^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:20:19
-   |
-20 |                if invisible_chars.contains(&ch) {
-   |                   ^^^^^^^^^^^^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:20:35
-   |
-20 |                if invisible_chars.contains(&ch) {
-   |                                   ^^^^^^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:20:45
-   |
-20 |                if invisible_chars.contains(&ch) {
-   |                                             ^^
-   |
-error: Unsupported feature.
-  --> lib.cairo:20:47
-   |
-20 |                if invisible_chars.contains(&ch) {
-   |                                               ^
-   |
-warning: Unused variable. Consider ignoring by prefixing with `_`.
-  --> lib.cairo:20:19
-   |
-20 |                if invisible_chars.contains(&ch) {
-   |                   ---------------
-   |
-warning: Unused variable. Consider ignoring by prefixing with `_`.
-  --> lib.cairo:20:45
-   |
-20 |                if invisible_chars.contains(&ch) {
-   |                                             --
-   |
-error: Unexpected type for tuple pattern. "<missing>" is not a tuple.
-  --> lib.cairo:22:28
-   |
-22 |                    println!("Invisible character detected at index {} in filename.", index);
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:22:28
-   |
-22 |                    println!("Invisible character detected at index {} in filename.", index);
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-error: Unsupported feature.
-  --> lib.cairo:22:92
-   |
-22 |                    println!("Invisible character detected at index {} in filename.", index);
-   |                                                                                            ^
-   |
-warning: Unused variable. Consider ignoring by prefixing with `_`.
-  --> lib.cairo:22:20
-   |
-22 |                    println!("Invisible character detected at index {} in filename.", index);
-   |                    -------
-   |
-error: Missing semicolon
-  --> lib.cairo:28:13
-   |
-28 |            },
-   |             ^
-   |
-error: Identifier not found.
-  --> lib.cairo:30:12
-   |
-30 |            None => {
-   |            ^^^^
-   |
-error: Missing semicolon
-  --> lib.cairo:30:16
-   |
-30 |            None => {
-   |                ^
-   |
-error: `break` only allowed inside a `loop`.
-  --> lib.cairo:32:16
-   |
-32 |                break;
-   |                ^^^^^^
-   |
-warning: Unused variable. Consider ignoring by prefixing with `_`.
- --> lib.cairo:4:8
+ --> lib.cairo:2:8
   |
-4 |    let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
-  |        ---------------
+2 |    let text = "Hello\u{200B}World!";
+  |        ----
+  |
+error: Type annotations needed. Failed to infer ?0.
+ --> lib.cairo:2:15
+  |
+2 |    let text = "Hello\u{200B}World!";
+  |               ^^^^^^^^^^^^^^^^^^^^^
   |
 
 //! > fixed
 fn main() {
-   let filename = "file\u{200B}name.txt";
-   let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
-
-   let mut index = 0;
-   let chars: Vec<char> = filename.chars().collect();
-
-   loop {
-       match chars.get(index) {
-           Some(&ch) => {
-               if invisible_chars.contains(&ch) {
-                   println!("Invisible character detected at index {} in filename.", index);
-               }
-               index += 1;
-           },
-           None => {
-               break;
-           },
-       }
-   }
+   let text = "Hello\u{200B}World!";
 }
 
 //! > ==========================================================================
 
-//! > loop check invisible characters in identifier
+//! > loop check for soft hyphen
 
 //! > cairo_code
 fn main() {
-   let text = "variable\u{200B}name";
-   let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
-
-   let mut index = 0;
-   let chars: Vec<char> = text.chars().collect();
-
-   loop {
-       match chars.get(index) {
-           Some(&ch) => {
-               if invisible_chars.contains(&ch) {
-                   println!("Invisible character detected at index {} in identifier.", index);
-               }
-               index += 1;
-           },
-           None => {
-               break;
-           },
-       }
-   }
+   let text = "Hyphen\u{00AD}Here";
 }
 
 //! > diagnostics
-error: Type not found.
-  --> lib.cairo:10:15
-   |
-10 |    let chars: Vec<char> = text.chars().collect();
-   |               ^^^
-   |
-error: Method `chars` not found on type `?0`. Did you import the correct trait and impl?
-  --> lib.cairo:10:32
-   |
-10 |    let chars: Vec<char> = text.chars().collect();
-   |                                ^^^^^
-   |
-error: Method `collect` not found on type `<missing>`. Did you import the correct trait and impl?
-  --> lib.cairo:10:40
-   |
-10 |    let chars: Vec<char> = text.chars().collect();
-   |                                        ^^^^^^^
-   |
-error: Ambiguous method call. More than one applicable trait function with a suitable self type was found: ArrayTrait::get and SpanTrait::get. Consider adding type annotations or explicitly refer to the impl function.
-  --> lib.cairo:16:20
-   |
-16 |        match chars.get(index) {
-   |                    ^^^
-   |
-error: Identifier not found.
-  --> lib.cairo:18:12
-   |
-18 |            Some(&ch) => {
-   |            ^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:18:12
-   |
-18 |            Some(&ch) => {
-   |            ^^^^^
-   |
-error: Unsupported feature.
-  --> lib.cairo:18:20
-   |
-18 |            Some(&ch) => {
-   |                    ^
-   |
 warning: Unused variable. Consider ignoring by prefixing with `_`.
-  --> lib.cairo:18:18
-   |
-18 |            Some(&ch) => {
-   |                  --
-   |
-error: Identifier not found.
-  --> lib.cairo:20:35
-   |
-20 |                if invisible_chars.contains(&ch) {
-   |                                   ^^^^^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:20:19
-   |
-20 |                if invisible_chars.contains(&ch) {
-   |                   ^^^^^^^^^^^^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:20:35
-   |
-20 |                if invisible_chars.contains(&ch) {
-   |                                   ^^^^^^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:20:45
-   |
-20 |                if invisible_chars.contains(&ch) {
-   |                                             ^^
-   |
-error: Unsupported feature.
-  --> lib.cairo:20:47
-   |
-20 |                if invisible_chars.contains(&ch) {
-   |                                               ^
-   |
-warning: Unused variable. Consider ignoring by prefixing with `_`.
-  --> lib.cairo:20:19
-   |
-20 |                if invisible_chars.contains(&ch) {
-   |                   ---------------
-   |
-warning: Unused variable. Consider ignoring by prefixing with `_`.
-  --> lib.cairo:20:45
-   |
-20 |                if invisible_chars.contains(&ch) {
-   |                                             --
-   |
-error: Unexpected type for tuple pattern. "<missing>" is not a tuple.
-  --> lib.cairo:22:28
-   |
-22 |                    println!("Invisible character detected at index {} in identifier.", index);
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:22:28
-   |
-22 |                    println!("Invisible character detected at index {} in identifier.", index);
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-error: Unsupported feature.
-  --> lib.cairo:22:94
-   |
-22 |                    println!("Invisible character detected at index {} in identifier.", index);
-   |                                                                                              ^
-   |
-warning: Unused variable. Consider ignoring by prefixing with `_`.
-  --> lib.cairo:22:20
-   |
-22 |                    println!("Invisible character detected at index {} in identifier.", index);
-   |                    -------
-   |
-error: Missing semicolon
-  --> lib.cairo:28:13
-   |
-28 |            },
-   |             ^
-   |
-error: Identifier not found.
-  --> lib.cairo:30:12
-   |
-30 |            None => {
-   |            ^^^^
-   |
-error: Missing semicolon
-  --> lib.cairo:30:16
-   |
-30 |            None => {
-   |                ^
-   |
-error: `break` only allowed inside a `loop`.
-  --> lib.cairo:32:16
-   |
-32 |                break;
-   |                ^^^^^^
-   |
-warning: Unused variable. Consider ignoring by prefixing with `_`.
- --> lib.cairo:4:8
+ --> lib.cairo:2:8
   |
-4 |    let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
-  |        ---------------
+2 |    let text = "Hyphen\u{00AD}Here";
+  |        ----
+  |
+error: Type annotations needed. Failed to infer ?0.
+ --> lib.cairo:2:15
+  |
+2 |    let text = "Hyphen\u{00AD}Here";
+  |               ^^^^^^^^^^^^^^^^^^^^
   |
 
 //! > fixed
 fn main() {
-   let text = "variable\u{200B}name";
-   let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
-
-   let mut index = 0;
-   let chars: Vec<char> = text.chars().collect();
-
-   loop {
-       match chars.get(index) {
-           Some(&ch) => {
-               if invisible_chars.contains(&ch) {
-                   println!("Invisible character detected at index {} in identifier.", index);
-               }
-               index += 1;
-           },
-           None => {
-               break;
-           },
-       }
-   }
-}
-
-//! > ==========================================================================
-
-//! > loop check invisible characters in number
-
-//! > cairo_code
-fn main() {
-    let text = "123\u{200B}456\u{2060}789";
-    let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
-
-    let mut index = 0;
-    let chars: Vec<char> = text.chars().collect();
-
-    loop {
-        match chars.get(index) {
-            Some(&ch) => {
-                if invisible_chars.contains(&ch) {
-                    println!("Invisible character detected at index {}: {}", index, ch.escape_unicode());
-                }
-                index += 1;
-            },
-            None => {
-                break;
-            },
-        }
-    }
-}
-
-//! > diagnostics
-error: Type not found.
-  --> lib.cairo:10:16
-   |
-10 |     let chars: Vec<char> = text.chars().collect();
-   |                ^^^
-   |
-error: Method `chars` not found on type `?0`. Did you import the correct trait and impl?
-  --> lib.cairo:10:33
-   |
-10 |     let chars: Vec<char> = text.chars().collect();
-   |                                 ^^^^^
-   |
-error: Method `collect` not found on type `<missing>`. Did you import the correct trait and impl?
-  --> lib.cairo:10:41
-   |
-10 |     let chars: Vec<char> = text.chars().collect();
-   |                                         ^^^^^^^
-   |
-error: Ambiguous method call. More than one applicable trait function with a suitable self type was found: ArrayTrait::get and SpanTrait::get. Consider adding type annotations or explicitly refer to the impl function.
-  --> lib.cairo:16:21
-   |
-16 |         match chars.get(index) {
-   |                     ^^^
-   |
-error: Identifier not found.
-  --> lib.cairo:18:13
-   |
-18 |             Some(&ch) => {
-   |             ^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:18:13
-   |
-18 |             Some(&ch) => {
-   |             ^^^^^
-   |
-error: Unsupported feature.
-  --> lib.cairo:18:21
-   |
-18 |             Some(&ch) => {
-   |                     ^
-   |
-warning: Unused variable. Consider ignoring by prefixing with `_`.
-  --> lib.cairo:18:19
-   |
-18 |             Some(&ch) => {
-   |                   --
-   |
-error: Identifier not found.
-  --> lib.cairo:20:36
-   |
-20 |                 if invisible_chars.contains(&ch) {
-   |                                    ^^^^^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:20:20
-   |
-20 |                 if invisible_chars.contains(&ch) {
-   |                    ^^^^^^^^^^^^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:20:36
-   |
-20 |                 if invisible_chars.contains(&ch) {
-   |                                    ^^^^^^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:20:46
-   |
-20 |                 if invisible_chars.contains(&ch) {
-   |                                              ^^
-   |
-error: Unsupported feature.
-  --> lib.cairo:20:48
-   |
-20 |                 if invisible_chars.contains(&ch) {
-   |                                                ^
-   |
-warning: Unused variable. Consider ignoring by prefixing with `_`.
-  --> lib.cairo:20:20
-   |
-20 |                 if invisible_chars.contains(&ch) {
-   |                    ---------------
-   |
-warning: Unused variable. Consider ignoring by prefixing with `_`.
-  --> lib.cairo:20:46
-   |
-20 |                 if invisible_chars.contains(&ch) {
-   |                                              --
-   |
-error: Unexpected type for tuple pattern. "<missing>" is not a tuple.
-  --> lib.cairo:22:29
-   |
-22 |                     println!("Invisible character detected at index {}: {}", index, ch.escape_unicode());
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:22:29
-   |
-22 |                     println!("Invisible character detected at index {}: {}", index, ch.escape_unicode());
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-error: Unsupported feature.
-  --> lib.cairo:22:105
-   |
-22 |                     println!("Invisible character detected at index {}: {}", index, ch.escape_unicode());
-   |                                                                                                         ^
-   |
-warning: Unused variable. Consider ignoring by prefixing with `_`.
-  --> lib.cairo:22:21
-   |
-22 |                     println!("Invisible character detected at index {}: {}", index, ch.escape_unicode());
-   |                     -------
-   |
-error: Missing semicolon
-  --> lib.cairo:28:14
-   |
-28 |             },
-   |              ^
-   |
-error: Identifier not found.
-  --> lib.cairo:30:13
-   |
-30 |             None => {
-   |             ^^^^
-   |
-error: Missing semicolon
-  --> lib.cairo:30:17
-   |
-30 |             None => {
-   |                 ^
-   |
-error: `break` only allowed inside a `loop`.
-  --> lib.cairo:32:17
-   |
-32 |                 break;
-   |                 ^^^^^^
-   |
-warning: Unused variable. Consider ignoring by prefixing with `_`.
- --> lib.cairo:4:9
-  |
-4 |     let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
-  |         ---------------
-  |
-
-//! > fixed
-fn main() {
-    let text = "123\u{200B}456\u{2060}789";
-    let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
-
-    let mut index = 0;
-    let chars: Vec<char> = text.chars().collect();
-
-    loop {
-        match chars.get(index) {
-            Some(&ch) => {
-                if invisible_chars.contains(&ch) {
-                    println!("Invisible character detected at index {}: {}", index, ch.escape_unicode());
-                }
-                index += 1;
-            },
-            None => {
-                break;
-            },
-        }
-    }
-}
-
-//! > ==========================================================================
-
-//! > loop check multiple invisible characters
-
-//! > cairo_code
-fn main() {
-    let text = "Data\u{200B}:\u{2060}Value\u{FEFF}";
-    let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
-
-    let mut index = 0;
-    let chars: Vec<char> = text.chars().collect();
-
-    loop {
-        match chars.get(index) {
-            Some(&ch) => {
-                if invisible_chars.contains(&ch) {
-                    println!("Multiple invisible characters detected at index {}: {}", index, ch.escape_unicode());
-                }
-                index += 1;
-            },
-            None => {
-                break;
-            },
-        }
-    }
-}
-
-//! > diagnostics
-error: Type not found.
-  --> lib.cairo:10:16
-   |
-10 |     let chars: Vec<char> = text.chars().collect();
-   |                ^^^
-   |
-error: Method `chars` not found on type `?0`. Did you import the correct trait and impl?
-  --> lib.cairo:10:33
-   |
-10 |     let chars: Vec<char> = text.chars().collect();
-   |                                 ^^^^^
-   |
-error: Method `collect` not found on type `<missing>`. Did you import the correct trait and impl?
-  --> lib.cairo:10:41
-   |
-10 |     let chars: Vec<char> = text.chars().collect();
-   |                                         ^^^^^^^
-   |
-error: Ambiguous method call. More than one applicable trait function with a suitable self type was found: ArrayTrait::get and SpanTrait::get. Consider adding type annotations or explicitly refer to the impl function.
-  --> lib.cairo:16:21
-   |
-16 |         match chars.get(index) {
-   |                     ^^^
-   |
-error: Identifier not found.
-  --> lib.cairo:18:13
-   |
-18 |             Some(&ch) => {
-   |             ^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:18:13
-   |
-18 |             Some(&ch) => {
-   |             ^^^^^
-   |
-error: Unsupported feature.
-  --> lib.cairo:18:21
-   |
-18 |             Some(&ch) => {
-   |                     ^
-   |
-warning: Unused variable. Consider ignoring by prefixing with `_`.
-  --> lib.cairo:18:19
-   |
-18 |             Some(&ch) => {
-   |                   --
-   |
-error: Identifier not found.
-  --> lib.cairo:20:36
-   |
-20 |                 if invisible_chars.contains(&ch) {
-   |                                    ^^^^^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:20:20
-   |
-20 |                 if invisible_chars.contains(&ch) {
-   |                    ^^^^^^^^^^^^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:20:36
-   |
-20 |                 if invisible_chars.contains(&ch) {
-   |                                    ^^^^^^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:20:46
-   |
-20 |                 if invisible_chars.contains(&ch) {
-   |                                              ^^
-   |
-error: Unsupported feature.
-  --> lib.cairo:20:48
-   |
-20 |                 if invisible_chars.contains(&ch) {
-   |                                                ^
-   |
-warning: Unused variable. Consider ignoring by prefixing with `_`.
-  --> lib.cairo:20:20
-   |
-20 |                 if invisible_chars.contains(&ch) {
-   |                    ---------------
-   |
-warning: Unused variable. Consider ignoring by prefixing with `_`.
-  --> lib.cairo:20:46
-   |
-20 |                 if invisible_chars.contains(&ch) {
-   |                                              --
-   |
-error: Unexpected type for tuple pattern. "<missing>" is not a tuple.
-  --> lib.cairo:22:29
-   |
-22 |                     println!("Multiple invisible characters detected at index {}: {}", index, ch.escape_unicode());
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-error: Missing variable in pattern.
-  --> lib.cairo:22:29
-   |
-22 |                     println!("Multiple invisible characters detected at index {}: {}", index, ch.escape_unicode());
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-error: Unsupported feature.
-  --> lib.cairo:22:115
-   |
-22 |                     println!("Multiple invisible characters detected at index {}: {}", index, ch.escape_unicode());
-   |                                                                                                                   ^
-   |
-warning: Unused variable. Consider ignoring by prefixing with `_`.
-  --> lib.cairo:22:21
-   |
-22 |                     println!("Multiple invisible characters detected at index {}: {}", index, ch.escape_unicode());
-   |                     -------
-   |
-error: Missing semicolon
-  --> lib.cairo:28:14
-   |
-28 |             },
-   |              ^
-   |
-error: Identifier not found.
-  --> lib.cairo:30:13
-   |
-30 |             None => {
-   |             ^^^^
-   |
-error: Missing semicolon
-  --> lib.cairo:30:17
-   |
-30 |             None => {
-   |                 ^
-   |
-error: `break` only allowed inside a `loop`.
-  --> lib.cairo:32:17
-   |
-32 |                 break;
-   |                 ^^^^^^
-   |
-warning: Unused variable. Consider ignoring by prefixing with `_`.
- --> lib.cairo:4:9
-  |
-4 |     let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
-  |         ---------------
-  |
-
-//! > fixed
-fn main() {
-    let text = "Data\u{200B}:\u{2060}Value\u{FEFF}";
-    let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
-
-    let mut index = 0;
-    let chars: Vec<char> = text.chars().collect();
-
-    loop {
-        match chars.get(index) {
-            Some(&ch) => {
-                if invisible_chars.contains(&ch) {
-                    println!("Multiple invisible characters detected at index {}: {}", index, ch.escape_unicode());
-                }
-                index += 1;
-            },
-            None => {
-                break;
-            },
-        }
-    }
+   let text = "Hyphen\u{00AD}Here";
 }

--- a/crates/cairo-lint-core/tests/test_files/invisible_characters/invisible_characters
+++ b/crates/cairo-lint-core/tests/test_files/invisible_characters/invisible_characters
@@ -194,6 +194,202 @@ fn main() {
 
 //! > ==========================================================================
 
+//! > loop check invisible characters in URL
+
+//! > cairo_code
+fn main() {
+   let text = "https://example\u{200B}.com";
+   let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
+
+   let mut index = 0;
+   let chars: Vec<char> = text.chars().collect();
+
+   loop {
+       match chars.get(index) {
+           Some(&ch) => {
+               if invisible_chars.contains(&ch) {
+                   println!("Invisible character detected at index {} in URL.", index);
+               }
+               index += 1;
+           },
+           None => {
+               break;
+           },
+       }
+   }
+}
+
+//! > diagnostics
+error: Type not found.
+  --> lib.cairo:10:15
+   |
+10 |    let chars: Vec<char> = text.chars().collect();
+   |               ^^^
+   |
+error: Method `chars` not found on type `?0`. Did you import the correct trait and impl?
+  --> lib.cairo:10:32
+   |
+10 |    let chars: Vec<char> = text.chars().collect();
+   |                                ^^^^^
+   |
+error: Method `collect` not found on type `<missing>`. Did you import the correct trait and impl?
+  --> lib.cairo:10:40
+   |
+10 |    let chars: Vec<char> = text.chars().collect();
+   |                                        ^^^^^^^
+   |
+error: Ambiguous method call. More than one applicable trait function with a suitable self type was found: ArrayTrait::get and SpanTrait::get. Consider adding type annotations or explicitly refer to the impl function.
+  --> lib.cairo:16:20
+   |
+16 |        match chars.get(index) {
+   |                    ^^^
+   |
+error: Identifier not found.
+  --> lib.cairo:18:12
+   |
+18 |            Some(&ch) => {
+   |            ^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:18:12
+   |
+18 |            Some(&ch) => {
+   |            ^^^^^
+   |
+error: Unsupported feature.
+  --> lib.cairo:18:20
+   |
+18 |            Some(&ch) => {
+   |                    ^
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+  --> lib.cairo:18:18
+   |
+18 |            Some(&ch) => {
+   |                  --
+   |
+error: Identifier not found.
+  --> lib.cairo:20:35
+   |
+20 |                if invisible_chars.contains(&ch) {
+   |                                   ^^^^^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:20:19
+   |
+20 |                if invisible_chars.contains(&ch) {
+   |                   ^^^^^^^^^^^^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:20:35
+   |
+20 |                if invisible_chars.contains(&ch) {
+   |                                   ^^^^^^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:20:45
+   |
+20 |                if invisible_chars.contains(&ch) {
+   |                                             ^^
+   |
+error: Unsupported feature.
+  --> lib.cairo:20:47
+   |
+20 |                if invisible_chars.contains(&ch) {
+   |                                               ^
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+  --> lib.cairo:20:19
+   |
+20 |                if invisible_chars.contains(&ch) {
+   |                   ---------------
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+  --> lib.cairo:20:45
+   |
+20 |                if invisible_chars.contains(&ch) {
+   |                                             --
+   |
+error: Unexpected type for tuple pattern. "<missing>" is not a tuple.
+  --> lib.cairo:22:28
+   |
+22 |                    println!("Invisible character detected at index {} in URL.", index);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:22:28
+   |
+22 |                    println!("Invisible character detected at index {} in URL.", index);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+error: Unsupported feature.
+  --> lib.cairo:22:87
+   |
+22 |                    println!("Invisible character detected at index {} in URL.", index);
+   |                                                                                       ^
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+  --> lib.cairo:22:20
+   |
+22 |                    println!("Invisible character detected at index {} in URL.", index);
+   |                    -------
+   |
+error: Missing semicolon
+  --> lib.cairo:28:13
+   |
+28 |            },
+   |             ^
+   |
+error: Identifier not found.
+  --> lib.cairo:30:12
+   |
+30 |            None => {
+   |            ^^^^
+   |
+error: Missing semicolon
+  --> lib.cairo:30:16
+   |
+30 |            None => {
+   |                ^
+   |
+error: `break` only allowed inside a `loop`.
+  --> lib.cairo:32:16
+   |
+32 |                break;
+   |                ^^^^^^
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+ --> lib.cairo:4:8
+  |
+4 |    let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
+  |        ---------------
+  |
+
+//! > fixed
+fn main() {
+   let text = "https://example\u{200B}.com";
+   let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
+
+   let mut index = 0;
+   let chars: Vec<char> = text.chars().collect();
+
+   loop {
+       match chars.get(index) {
+           Some(&ch) => {
+               if invisible_chars.contains(&ch) {
+                   println!("Invisible character detected at index {} in URL.", index);
+               }
+               index += 1;
+           },
+           None => {
+               break;
+           },
+       }
+   }
+}
+
+//! > ==========================================================================
+
 //! > loop check invisible characters in comments
 
 //! > cairo_code
@@ -368,6 +564,790 @@ warning: Unused variable. Consider ignoring by prefixing with `_`.
 //! > fixed
 fn main() {
     let text = "HelloWorld! // Comment with invisible\u{200B}character";
+    let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
+
+    let mut index = 0;
+    let chars: Vec<char> = text.chars().collect();
+
+    loop {
+        match chars.get(index) {
+            Some(&ch) => {
+                if invisible_chars.contains(&ch) {
+                    println!("Invisible character detected at index {}: {}", index, ch.escape_unicode());
+                }
+                index += 1;
+            },
+            None => {
+                break;
+            },
+        }
+    }
+}
+
+//! > ==========================================================================
+
+//! > loop check invisible characters in config
+
+//! > cairo_code
+fn main() {
+   let config = "setting\u{200B}=true";
+   let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
+
+   let mut index = 0;
+   let chars: Vec<char> = config.chars().collect();
+
+   loop {
+       match chars.get(index) {
+           Some(&ch) => {
+               if invisible_chars.contains(&ch) {
+                   println!("Invisible character detected at index {} in configuration.", index);
+               }
+               index += 1;
+           },
+           None => {
+               break;
+           },
+       }
+   }
+}
+
+//! > diagnostics
+error: Type not found.
+  --> lib.cairo:10:15
+   |
+10 |    let chars: Vec<char> = config.chars().collect();
+   |               ^^^
+   |
+error: Method `chars` not found on type `?0`. Did you import the correct trait and impl?
+  --> lib.cairo:10:34
+   |
+10 |    let chars: Vec<char> = config.chars().collect();
+   |                                  ^^^^^
+   |
+error: Method `collect` not found on type `<missing>`. Did you import the correct trait and impl?
+  --> lib.cairo:10:42
+   |
+10 |    let chars: Vec<char> = config.chars().collect();
+   |                                          ^^^^^^^
+   |
+error: Ambiguous method call. More than one applicable trait function with a suitable self type was found: ArrayTrait::get and SpanTrait::get. Consider adding type annotations or explicitly refer to the impl function.
+  --> lib.cairo:16:20
+   |
+16 |        match chars.get(index) {
+   |                    ^^^
+   |
+error: Identifier not found.
+  --> lib.cairo:18:12
+   |
+18 |            Some(&ch) => {
+   |            ^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:18:12
+   |
+18 |            Some(&ch) => {
+   |            ^^^^^
+   |
+error: Unsupported feature.
+  --> lib.cairo:18:20
+   |
+18 |            Some(&ch) => {
+   |                    ^
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+  --> lib.cairo:18:18
+   |
+18 |            Some(&ch) => {
+   |                  --
+   |
+error: Identifier not found.
+  --> lib.cairo:20:35
+   |
+20 |                if invisible_chars.contains(&ch) {
+   |                                   ^^^^^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:20:19
+   |
+20 |                if invisible_chars.contains(&ch) {
+   |                   ^^^^^^^^^^^^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:20:35
+   |
+20 |                if invisible_chars.contains(&ch) {
+   |                                   ^^^^^^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:20:45
+   |
+20 |                if invisible_chars.contains(&ch) {
+   |                                             ^^
+   |
+error: Unsupported feature.
+  --> lib.cairo:20:47
+   |
+20 |                if invisible_chars.contains(&ch) {
+   |                                               ^
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+  --> lib.cairo:20:19
+   |
+20 |                if invisible_chars.contains(&ch) {
+   |                   ---------------
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+  --> lib.cairo:20:45
+   |
+20 |                if invisible_chars.contains(&ch) {
+   |                                             --
+   |
+error: Unexpected type for tuple pattern. "<missing>" is not a tuple.
+  --> lib.cairo:22:28
+   |
+22 |                    println!("Invisible character detected at index {} in configuration.", index);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:22:28
+   |
+22 |                    println!("Invisible character detected at index {} in configuration.", index);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+error: Unsupported feature.
+  --> lib.cairo:22:97
+   |
+22 |                    println!("Invisible character detected at index {} in configuration.", index);
+   |                                                                                                 ^
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+  --> lib.cairo:22:20
+   |
+22 |                    println!("Invisible character detected at index {} in configuration.", index);
+   |                    -------
+   |
+error: Missing semicolon
+  --> lib.cairo:28:13
+   |
+28 |            },
+   |             ^
+   |
+error: Identifier not found.
+  --> lib.cairo:30:12
+   |
+30 |            None => {
+   |            ^^^^
+   |
+error: Missing semicolon
+  --> lib.cairo:30:16
+   |
+30 |            None => {
+   |                ^
+   |
+error: `break` only allowed inside a `loop`.
+  --> lib.cairo:32:16
+   |
+32 |                break;
+   |                ^^^^^^
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+ --> lib.cairo:4:8
+  |
+4 |    let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
+  |        ---------------
+  |
+
+//! > fixed
+fn main() {
+   let config = "setting\u{200B}=true";
+   let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
+
+   let mut index = 0;
+   let chars: Vec<char> = config.chars().collect();
+
+   loop {
+       match chars.get(index) {
+           Some(&ch) => {
+               if invisible_chars.contains(&ch) {
+                   println!("Invisible character detected at index {} in configuration.", index);
+               }
+               index += 1;
+           },
+           None => {
+               break;
+           },
+       }
+   }
+}
+
+//! > ==========================================================================
+
+//! > loop check invisible characters in filename
+
+//! > cairo_code
+fn main() {
+   let filename = "file\u{200B}name.txt";
+   let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
+
+   let mut index = 0;
+   let chars: Vec<char> = filename.chars().collect();
+
+   loop {
+       match chars.get(index) {
+           Some(&ch) => {
+               if invisible_chars.contains(&ch) {
+                   println!("Invisible character detected at index {} in filename.", index);
+               }
+               index += 1;
+           },
+           None => {
+               break;
+           },
+       }
+   }
+}
+
+//! > diagnostics
+error: Type not found.
+  --> lib.cairo:10:15
+   |
+10 |    let chars: Vec<char> = filename.chars().collect();
+   |               ^^^
+   |
+error: Method `chars` not found on type `?0`. Did you import the correct trait and impl?
+  --> lib.cairo:10:36
+   |
+10 |    let chars: Vec<char> = filename.chars().collect();
+   |                                    ^^^^^
+   |
+error: Method `collect` not found on type `<missing>`. Did you import the correct trait and impl?
+  --> lib.cairo:10:44
+   |
+10 |    let chars: Vec<char> = filename.chars().collect();
+   |                                            ^^^^^^^
+   |
+error: Ambiguous method call. More than one applicable trait function with a suitable self type was found: ArrayTrait::get and SpanTrait::get. Consider adding type annotations or explicitly refer to the impl function.
+  --> lib.cairo:16:20
+   |
+16 |        match chars.get(index) {
+   |                    ^^^
+   |
+error: Identifier not found.
+  --> lib.cairo:18:12
+   |
+18 |            Some(&ch) => {
+   |            ^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:18:12
+   |
+18 |            Some(&ch) => {
+   |            ^^^^^
+   |
+error: Unsupported feature.
+  --> lib.cairo:18:20
+   |
+18 |            Some(&ch) => {
+   |                    ^
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+  --> lib.cairo:18:18
+   |
+18 |            Some(&ch) => {
+   |                  --
+   |
+error: Identifier not found.
+  --> lib.cairo:20:35
+   |
+20 |                if invisible_chars.contains(&ch) {
+   |                                   ^^^^^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:20:19
+   |
+20 |                if invisible_chars.contains(&ch) {
+   |                   ^^^^^^^^^^^^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:20:35
+   |
+20 |                if invisible_chars.contains(&ch) {
+   |                                   ^^^^^^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:20:45
+   |
+20 |                if invisible_chars.contains(&ch) {
+   |                                             ^^
+   |
+error: Unsupported feature.
+  --> lib.cairo:20:47
+   |
+20 |                if invisible_chars.contains(&ch) {
+   |                                               ^
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+  --> lib.cairo:20:19
+   |
+20 |                if invisible_chars.contains(&ch) {
+   |                   ---------------
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+  --> lib.cairo:20:45
+   |
+20 |                if invisible_chars.contains(&ch) {
+   |                                             --
+   |
+error: Unexpected type for tuple pattern. "<missing>" is not a tuple.
+  --> lib.cairo:22:28
+   |
+22 |                    println!("Invisible character detected at index {} in filename.", index);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:22:28
+   |
+22 |                    println!("Invisible character detected at index {} in filename.", index);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+error: Unsupported feature.
+  --> lib.cairo:22:92
+   |
+22 |                    println!("Invisible character detected at index {} in filename.", index);
+   |                                                                                            ^
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+  --> lib.cairo:22:20
+   |
+22 |                    println!("Invisible character detected at index {} in filename.", index);
+   |                    -------
+   |
+error: Missing semicolon
+  --> lib.cairo:28:13
+   |
+28 |            },
+   |             ^
+   |
+error: Identifier not found.
+  --> lib.cairo:30:12
+   |
+30 |            None => {
+   |            ^^^^
+   |
+error: Missing semicolon
+  --> lib.cairo:30:16
+   |
+30 |            None => {
+   |                ^
+   |
+error: `break` only allowed inside a `loop`.
+  --> lib.cairo:32:16
+   |
+32 |                break;
+   |                ^^^^^^
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+ --> lib.cairo:4:8
+  |
+4 |    let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
+  |        ---------------
+  |
+
+//! > fixed
+fn main() {
+   let filename = "file\u{200B}name.txt";
+   let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
+
+   let mut index = 0;
+   let chars: Vec<char> = filename.chars().collect();
+
+   loop {
+       match chars.get(index) {
+           Some(&ch) => {
+               if invisible_chars.contains(&ch) {
+                   println!("Invisible character detected at index {} in filename.", index);
+               }
+               index += 1;
+           },
+           None => {
+               break;
+           },
+       }
+   }
+}
+
+//! > ==========================================================================
+
+//! > loop check invisible characters in identifier
+
+//! > cairo_code
+fn main() {
+   let text = "variable\u{200B}name";
+   let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
+
+   let mut index = 0;
+   let chars: Vec<char> = text.chars().collect();
+
+   loop {
+       match chars.get(index) {
+           Some(&ch) => {
+               if invisible_chars.contains(&ch) {
+                   println!("Invisible character detected at index {} in identifier.", index);
+               }
+               index += 1;
+           },
+           None => {
+               break;
+           },
+       }
+   }
+}
+
+//! > diagnostics
+error: Type not found.
+  --> lib.cairo:10:15
+   |
+10 |    let chars: Vec<char> = text.chars().collect();
+   |               ^^^
+   |
+error: Method `chars` not found on type `?0`. Did you import the correct trait and impl?
+  --> lib.cairo:10:32
+   |
+10 |    let chars: Vec<char> = text.chars().collect();
+   |                                ^^^^^
+   |
+error: Method `collect` not found on type `<missing>`. Did you import the correct trait and impl?
+  --> lib.cairo:10:40
+   |
+10 |    let chars: Vec<char> = text.chars().collect();
+   |                                        ^^^^^^^
+   |
+error: Ambiguous method call. More than one applicable trait function with a suitable self type was found: ArrayTrait::get and SpanTrait::get. Consider adding type annotations or explicitly refer to the impl function.
+  --> lib.cairo:16:20
+   |
+16 |        match chars.get(index) {
+   |                    ^^^
+   |
+error: Identifier not found.
+  --> lib.cairo:18:12
+   |
+18 |            Some(&ch) => {
+   |            ^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:18:12
+   |
+18 |            Some(&ch) => {
+   |            ^^^^^
+   |
+error: Unsupported feature.
+  --> lib.cairo:18:20
+   |
+18 |            Some(&ch) => {
+   |                    ^
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+  --> lib.cairo:18:18
+   |
+18 |            Some(&ch) => {
+   |                  --
+   |
+error: Identifier not found.
+  --> lib.cairo:20:35
+   |
+20 |                if invisible_chars.contains(&ch) {
+   |                                   ^^^^^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:20:19
+   |
+20 |                if invisible_chars.contains(&ch) {
+   |                   ^^^^^^^^^^^^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:20:35
+   |
+20 |                if invisible_chars.contains(&ch) {
+   |                                   ^^^^^^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:20:45
+   |
+20 |                if invisible_chars.contains(&ch) {
+   |                                             ^^
+   |
+error: Unsupported feature.
+  --> lib.cairo:20:47
+   |
+20 |                if invisible_chars.contains(&ch) {
+   |                                               ^
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+  --> lib.cairo:20:19
+   |
+20 |                if invisible_chars.contains(&ch) {
+   |                   ---------------
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+  --> lib.cairo:20:45
+   |
+20 |                if invisible_chars.contains(&ch) {
+   |                                             --
+   |
+error: Unexpected type for tuple pattern. "<missing>" is not a tuple.
+  --> lib.cairo:22:28
+   |
+22 |                    println!("Invisible character detected at index {} in identifier.", index);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:22:28
+   |
+22 |                    println!("Invisible character detected at index {} in identifier.", index);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+error: Unsupported feature.
+  --> lib.cairo:22:94
+   |
+22 |                    println!("Invisible character detected at index {} in identifier.", index);
+   |                                                                                              ^
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+  --> lib.cairo:22:20
+   |
+22 |                    println!("Invisible character detected at index {} in identifier.", index);
+   |                    -------
+   |
+error: Missing semicolon
+  --> lib.cairo:28:13
+   |
+28 |            },
+   |             ^
+   |
+error: Identifier not found.
+  --> lib.cairo:30:12
+   |
+30 |            None => {
+   |            ^^^^
+   |
+error: Missing semicolon
+  --> lib.cairo:30:16
+   |
+30 |            None => {
+   |                ^
+   |
+error: `break` only allowed inside a `loop`.
+  --> lib.cairo:32:16
+   |
+32 |                break;
+   |                ^^^^^^
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+ --> lib.cairo:4:8
+  |
+4 |    let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
+  |        ---------------
+  |
+
+//! > fixed
+fn main() {
+   let text = "variable\u{200B}name";
+   let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
+
+   let mut index = 0;
+   let chars: Vec<char> = text.chars().collect();
+
+   loop {
+       match chars.get(index) {
+           Some(&ch) => {
+               if invisible_chars.contains(&ch) {
+                   println!("Invisible character detected at index {} in identifier.", index);
+               }
+               index += 1;
+           },
+           None => {
+               break;
+           },
+       }
+   }
+}
+
+//! > ==========================================================================
+
+//! > loop check invisible characters in number
+
+//! > cairo_code
+fn main() {
+    let text = "123\u{200B}456\u{2060}789";
+    let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
+
+    let mut index = 0;
+    let chars: Vec<char> = text.chars().collect();
+
+    loop {
+        match chars.get(index) {
+            Some(&ch) => {
+                if invisible_chars.contains(&ch) {
+                    println!("Invisible character detected at index {}: {}", index, ch.escape_unicode());
+                }
+                index += 1;
+            },
+            None => {
+                break;
+            },
+        }
+    }
+}
+
+//! > diagnostics
+error: Type not found.
+  --> lib.cairo:10:16
+   |
+10 |     let chars: Vec<char> = text.chars().collect();
+   |                ^^^
+   |
+error: Method `chars` not found on type `?0`. Did you import the correct trait and impl?
+  --> lib.cairo:10:33
+   |
+10 |     let chars: Vec<char> = text.chars().collect();
+   |                                 ^^^^^
+   |
+error: Method `collect` not found on type `<missing>`. Did you import the correct trait and impl?
+  --> lib.cairo:10:41
+   |
+10 |     let chars: Vec<char> = text.chars().collect();
+   |                                         ^^^^^^^
+   |
+error: Ambiguous method call. More than one applicable trait function with a suitable self type was found: ArrayTrait::get and SpanTrait::get. Consider adding type annotations or explicitly refer to the impl function.
+  --> lib.cairo:16:21
+   |
+16 |         match chars.get(index) {
+   |                     ^^^
+   |
+error: Identifier not found.
+  --> lib.cairo:18:13
+   |
+18 |             Some(&ch) => {
+   |             ^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:18:13
+   |
+18 |             Some(&ch) => {
+   |             ^^^^^
+   |
+error: Unsupported feature.
+  --> lib.cairo:18:21
+   |
+18 |             Some(&ch) => {
+   |                     ^
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+  --> lib.cairo:18:19
+   |
+18 |             Some(&ch) => {
+   |                   --
+   |
+error: Identifier not found.
+  --> lib.cairo:20:36
+   |
+20 |                 if invisible_chars.contains(&ch) {
+   |                                    ^^^^^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:20:20
+   |
+20 |                 if invisible_chars.contains(&ch) {
+   |                    ^^^^^^^^^^^^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:20:36
+   |
+20 |                 if invisible_chars.contains(&ch) {
+   |                                    ^^^^^^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:20:46
+   |
+20 |                 if invisible_chars.contains(&ch) {
+   |                                              ^^
+   |
+error: Unsupported feature.
+  --> lib.cairo:20:48
+   |
+20 |                 if invisible_chars.contains(&ch) {
+   |                                                ^
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+  --> lib.cairo:20:20
+   |
+20 |                 if invisible_chars.contains(&ch) {
+   |                    ---------------
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+  --> lib.cairo:20:46
+   |
+20 |                 if invisible_chars.contains(&ch) {
+   |                                              --
+   |
+error: Unexpected type for tuple pattern. "<missing>" is not a tuple.
+  --> lib.cairo:22:29
+   |
+22 |                     println!("Invisible character detected at index {}: {}", index, ch.escape_unicode());
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:22:29
+   |
+22 |                     println!("Invisible character detected at index {}: {}", index, ch.escape_unicode());
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+error: Unsupported feature.
+  --> lib.cairo:22:105
+   |
+22 |                     println!("Invisible character detected at index {}: {}", index, ch.escape_unicode());
+   |                                                                                                         ^
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+  --> lib.cairo:22:21
+   |
+22 |                     println!("Invisible character detected at index {}: {}", index, ch.escape_unicode());
+   |                     -------
+   |
+error: Missing semicolon
+  --> lib.cairo:28:14
+   |
+28 |             },
+   |              ^
+   |
+error: Identifier not found.
+  --> lib.cairo:30:13
+   |
+30 |             None => {
+   |             ^^^^
+   |
+error: Missing semicolon
+  --> lib.cairo:30:17
+   |
+30 |             None => {
+   |                 ^
+   |
+error: `break` only allowed inside a `loop`.
+  --> lib.cairo:32:17
+   |
+32 |                 break;
+   |                 ^^^^^^
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+ --> lib.cairo:4:9
+  |
+4 |     let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
+  |         ---------------
+  |
+
+//! > fixed
+fn main() {
+    let text = "123\u{200B}456\u{2060}789";
     let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
 
     let mut index = 0;

--- a/crates/cairo-lint-core/tests/test_files/invisible_characters/invisible_characters
+++ b/crates/cairo-lint-core/tests/test_files/invisible_characters/invisible_characters
@@ -1,13 +1,22 @@
-//! > loop match pop front with spaces
+//! > loop check invisible characters
 
 //! > cairo_code
 fn main() {
-    let mut a: Span<u32> = array![ 1,  2,  3,  4,  5 ].span();  
+    let text = "Hello\u{200B}World\u{2060}!";
+    let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
+
+    let mut index = 0;
+    let chars: Vec<char> = text.chars().collect();
+
     loop {
-        match a.pop_front() {
-            Option::Some(val) => println!("{val}"),
-            Option::None => { 
-               
+        match chars.get(index) {
+            Some(&ch) => {
+                if invisible_chars.contains(&ch) {
+                    println!("Invisible character detected at index {}: {}", index, ch.escape_unicode());
+                }
+                index += 1;
+            },
+            None => {
                 break;
             },
         }
@@ -15,45 +24,195 @@ fn main() {
 }
 
 //! > diagnostics
-warning: Plugin diagnostic: you seem to be trying to use `loop` for iterating over a span. Consider using `for in`
-  --> lib.cairo:4:5
+error: Type not found.
+  --> lib.cairo:10:16
    |
- 4 |       loop {
-   |  _____-
- 5 | |         match a.pop_front() {
-...  |
-11 | |         }
-12 | |     }
-   | |_____-
+10 |     let chars: Vec<char> = text.chars().collect();
+   |                ^^^
    |
-warning: Plugin diagnostic: Whitespace detected.
- --> lib.cairo:2:28
+error: Method `chars` not found on type `?0`. Did you import the correct trait and impl?
+  --> lib.cairo:10:33
+   |
+10 |     let chars: Vec<char> = text.chars().collect();
+   |                                 ^^^^^
+   |
+error: Method `collect` not found on type `<missing>`. Did you import the correct trait and impl?
+  --> lib.cairo:10:41
+   |
+10 |     let chars: Vec<char> = text.chars().collect();
+   |                                         ^^^^^^^
+   |
+error: Ambiguous method call. More than one applicable trait function with a suitable self type was found: ArrayTrait::get and SpanTrait::get. Consider adding type annotations or explicitly refer to the impl function.
+  --> lib.cairo:16:21
+   |
+16 |         match chars.get(index) {
+   |                     ^^^
+   |
+error: Identifier not found.
+  --> lib.cairo:18:13
+   |
+18 |             Some(&ch) => {
+   |             ^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:18:13
+   |
+18 |             Some(&ch) => {
+   |             ^^^^^
+   |
+error: Unsupported feature.
+  --> lib.cairo:18:21
+   |
+18 |             Some(&ch) => {
+   |                     ^
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+  --> lib.cairo:18:19
+   |
+18 |             Some(&ch) => {
+   |                   --
+   |
+error: Identifier not found.
+  --> lib.cairo:20:36
+   |
+20 |                 if invisible_chars.contains(&ch) {
+   |                                    ^^^^^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:20:20
+   |
+20 |                 if invisible_chars.contains(&ch) {
+   |                    ^^^^^^^^^^^^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:20:36
+   |
+20 |                 if invisible_chars.contains(&ch) {
+   |                                    ^^^^^^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:20:46
+   |
+20 |                 if invisible_chars.contains(&ch) {
+   |                                              ^^
+   |
+error: Unsupported feature.
+  --> lib.cairo:20:48
+   |
+20 |                 if invisible_chars.contains(&ch) {
+   |                                                ^
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+  --> lib.cairo:20:20
+   |
+20 |                 if invisible_chars.contains(&ch) {
+   |                    ---------------
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+  --> lib.cairo:20:46
+   |
+20 |                 if invisible_chars.contains(&ch) {
+   |                                              --
+   |
+error: Unexpected type for tuple pattern. "<missing>" is not a tuple.
+  --> lib.cairo:22:29
+   |
+22 |                     println!("Invisible character detected at index {}: {}", index, ch.escape_unicode());
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:22:29
+   |
+22 |                     println!("Invisible character detected at index {}: {}", index, ch.escape_unicode());
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+error: Unsupported feature.
+  --> lib.cairo:22:105
+   |
+22 |                     println!("Invisible character detected at index {}: {}", index, ch.escape_unicode());
+   |                                                                                                         ^
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+  --> lib.cairo:22:21
+   |
+22 |                     println!("Invisible character detected at index {}: {}", index, ch.escape_unicode());
+   |                     -------
+   |
+error: Missing semicolon
+  --> lib.cairo:28:14
+   |
+28 |             },
+   |              ^
+   |
+error: Identifier not found.
+  --> lib.cairo:30:13
+   |
+30 |             None => {
+   |             ^^^^
+   |
+error: Missing semicolon
+  --> lib.cairo:30:17
+   |
+30 |             None => {
+   |                 ^
+   |
+error: `break` only allowed inside a `loop`.
+  --> lib.cairo:32:17
+   |
+32 |                 break;
+   |                 ^^^^^^
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+ --> lib.cairo:4:9
   |
-2 |     let mut a: Span<u32> = array![ 1,  2,  3,  4,  5 ].span();  
-  |                            ---------------------------
+4 |     let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
+  |         ---------------
   |
 
 //! > fixed
 fn main() {
-    let mut a: Span<u32> = array![1,2,3,4,5].span();  
+    let text = "Hello\u{200B}World\u{2060}!";
+    let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
 
-    for val in a {
-        println!("{val}")
-    };
+    let mut index = 0;
+    let chars: Vec<char> = text.chars().collect();
+
+    loop {
+        match chars.get(index) {
+            Some(&ch) => {
+                if invisible_chars.contains(&ch) {
+                    println!("Invisible character detected at index {}: {}", index, ch.escape_unicode());
+                }
+                index += 1;
+            },
+            None => {
+                break;
+            },
+        }
+    }
 }
 
 //! > ==========================================================================
 
-//! > loop match pop front with spaces in none
+//! > loop check invisible characters in comments
 
 //! > cairo_code
 fn main() {
-    let mut a: Span<u32> = array![ 1, 2, 3, 4, 5 ].span();
+    let text = "HelloWorld! // Comment with invisible\u{200B}character";
+    let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
+
+    let mut index = 0;
+    let chars: Vec<char> = text.chars().collect();
+
     loop {
-        match a.pop_front() {
-            Option::Some(val) => println!("{val}"),
-            Option::None => { 
-                println!("Finished looping  ");  
+        match chars.get(index) {
+            Some(&ch) => {
+                if invisible_chars.contains(&ch) {
+                    println!("Invisible character detected at index {}: {}", index, ch.escape_unicode());
+                }
+                index += 1;
+            },
+            None => {
                 break;
             },
         }
@@ -61,27 +220,168 @@ fn main() {
 }
 
 //! > diagnostics
-warning: Plugin diagnostic: Whitespace detected.
- --> lib.cairo:2:28
-  |
-2 |     let mut a: Span<u32> = array![ 1, 2, 3, 4, 5 ].span();
-  |                            -----------------------
-  |
-warning: Plugin diagnostic: Whitespace detected.
-  --> lib.cairo:12:17
+error: Type not found.
+  --> lib.cairo:10:16
    |
-12 |                 println!("Finished looping  ");  
-   |                 ------------------------------
+10 |     let chars: Vec<char> = text.chars().collect();
+   |                ^^^
    |
+error: Method `chars` not found on type `?0`. Did you import the correct trait and impl?
+  --> lib.cairo:10:33
+   |
+10 |     let chars: Vec<char> = text.chars().collect();
+   |                                 ^^^^^
+   |
+error: Method `collect` not found on type `<missing>`. Did you import the correct trait and impl?
+  --> lib.cairo:10:41
+   |
+10 |     let chars: Vec<char> = text.chars().collect();
+   |                                         ^^^^^^^
+   |
+error: Ambiguous method call. More than one applicable trait function with a suitable self type was found: ArrayTrait::get and SpanTrait::get. Consider adding type annotations or explicitly refer to the impl function.
+  --> lib.cairo:16:21
+   |
+16 |         match chars.get(index) {
+   |                     ^^^
+   |
+error: Identifier not found.
+  --> lib.cairo:18:13
+   |
+18 |             Some(&ch) => {
+   |             ^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:18:13
+   |
+18 |             Some(&ch) => {
+   |             ^^^^^
+   |
+error: Unsupported feature.
+  --> lib.cairo:18:21
+   |
+18 |             Some(&ch) => {
+   |                     ^
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+  --> lib.cairo:18:19
+   |
+18 |             Some(&ch) => {
+   |                   --
+   |
+error: Identifier not found.
+  --> lib.cairo:20:36
+   |
+20 |                 if invisible_chars.contains(&ch) {
+   |                                    ^^^^^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:20:20
+   |
+20 |                 if invisible_chars.contains(&ch) {
+   |                    ^^^^^^^^^^^^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:20:36
+   |
+20 |                 if invisible_chars.contains(&ch) {
+   |                                    ^^^^^^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:20:46
+   |
+20 |                 if invisible_chars.contains(&ch) {
+   |                                              ^^
+   |
+error: Unsupported feature.
+  --> lib.cairo:20:48
+   |
+20 |                 if invisible_chars.contains(&ch) {
+   |                                                ^
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+  --> lib.cairo:20:20
+   |
+20 |                 if invisible_chars.contains(&ch) {
+   |                    ---------------
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+  --> lib.cairo:20:46
+   |
+20 |                 if invisible_chars.contains(&ch) {
+   |                                              --
+   |
+error: Unexpected type for tuple pattern. "<missing>" is not a tuple.
+  --> lib.cairo:22:29
+   |
+22 |                     println!("Invisible character detected at index {}: {}", index, ch.escape_unicode());
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:22:29
+   |
+22 |                     println!("Invisible character detected at index {}: {}", index, ch.escape_unicode());
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+error: Unsupported feature.
+  --> lib.cairo:22:105
+   |
+22 |                     println!("Invisible character detected at index {}: {}", index, ch.escape_unicode());
+   |                                                                                                         ^
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+  --> lib.cairo:22:21
+   |
+22 |                     println!("Invisible character detected at index {}: {}", index, ch.escape_unicode());
+   |                     -------
+   |
+error: Missing semicolon
+  --> lib.cairo:28:14
+   |
+28 |             },
+   |              ^
+   |
+error: Identifier not found.
+  --> lib.cairo:30:13
+   |
+30 |             None => {
+   |             ^^^^
+   |
+error: Missing semicolon
+  --> lib.cairo:30:17
+   |
+30 |             None => {
+   |                 ^
+   |
+error: `break` only allowed inside a `loop`.
+  --> lib.cairo:32:17
+   |
+32 |                 break;
+   |                 ^^^^^^
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+ --> lib.cairo:4:9
+  |
+4 |     let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
+  |         ---------------
+  |
 
 //! > fixed
 fn main() {
-    let mut a: Span<u32> = array![1,2,3,4,5].span();
+    let text = "HelloWorld! // Comment with invisible\u{200B}character";
+    let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
+
+    let mut index = 0;
+    let chars: Vec<char> = text.chars().collect();
+
     loop {
-        match a.pop_front() {
-            Option::Some(val) => println!("{val}"),
-            Option::None => { 
-println!("Finishedlooping");  
+        match chars.get(index) {
+            Some(&ch) => {
+                if invisible_chars.contains(&ch) {
+                    println!("Invisible character detected at index {}: {}", index, ch.escape_unicode());
+                }
+                index += 1;
+            },
+            None => {
                 break;
             },
         }
@@ -90,16 +390,25 @@ println!("Finishedlooping");
 
 //! > ==========================================================================
 
-//! > simple loop match pop front with comment and spaces
+//! > loop check multiple invisible characters
 
 //! > cairo_code
 fn main() {
-    let mut a: Span<u32> = array![ 1,  2,  3,  4,  5 ].span();  // Extra spaces between elements
+    let text = "Data\u{200B}:\u{2060}Value\u{FEFF}";
+    let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
+
+    let mut index = 0;
+    let chars: Vec<char> = text.chars().collect();
+
     loop {
-        match a.pop_front() {
-            Option::Some(val) => println!("{val}"),
-            Option::None => { 
-                // Comment with space
+        match chars.get(index) {
+            Some(&ch) => {
+                if invisible_chars.contains(&ch) {
+                    println!("Multiple invisible characters detected at index {}: {}", index, ch.escape_unicode());
+                }
+                index += 1;
+            },
+            None => {
                 break;
             },
         }
@@ -107,21 +416,168 @@ fn main() {
 }
 
 //! > diagnostics
-warning: Plugin diagnostic: Whitespace detected.
- --> lib.cairo:2:28
+error: Type not found.
+  --> lib.cairo:10:16
+   |
+10 |     let chars: Vec<char> = text.chars().collect();
+   |                ^^^
+   |
+error: Method `chars` not found on type `?0`. Did you import the correct trait and impl?
+  --> lib.cairo:10:33
+   |
+10 |     let chars: Vec<char> = text.chars().collect();
+   |                                 ^^^^^
+   |
+error: Method `collect` not found on type `<missing>`. Did you import the correct trait and impl?
+  --> lib.cairo:10:41
+   |
+10 |     let chars: Vec<char> = text.chars().collect();
+   |                                         ^^^^^^^
+   |
+error: Ambiguous method call. More than one applicable trait function with a suitable self type was found: ArrayTrait::get and SpanTrait::get. Consider adding type annotations or explicitly refer to the impl function.
+  --> lib.cairo:16:21
+   |
+16 |         match chars.get(index) {
+   |                     ^^^
+   |
+error: Identifier not found.
+  --> lib.cairo:18:13
+   |
+18 |             Some(&ch) => {
+   |             ^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:18:13
+   |
+18 |             Some(&ch) => {
+   |             ^^^^^
+   |
+error: Unsupported feature.
+  --> lib.cairo:18:21
+   |
+18 |             Some(&ch) => {
+   |                     ^
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+  --> lib.cairo:18:19
+   |
+18 |             Some(&ch) => {
+   |                   --
+   |
+error: Identifier not found.
+  --> lib.cairo:20:36
+   |
+20 |                 if invisible_chars.contains(&ch) {
+   |                                    ^^^^^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:20:20
+   |
+20 |                 if invisible_chars.contains(&ch) {
+   |                    ^^^^^^^^^^^^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:20:36
+   |
+20 |                 if invisible_chars.contains(&ch) {
+   |                                    ^^^^^^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:20:46
+   |
+20 |                 if invisible_chars.contains(&ch) {
+   |                                              ^^
+   |
+error: Unsupported feature.
+  --> lib.cairo:20:48
+   |
+20 |                 if invisible_chars.contains(&ch) {
+   |                                                ^
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+  --> lib.cairo:20:20
+   |
+20 |                 if invisible_chars.contains(&ch) {
+   |                    ---------------
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+  --> lib.cairo:20:46
+   |
+20 |                 if invisible_chars.contains(&ch) {
+   |                                              --
+   |
+error: Unexpected type for tuple pattern. "<missing>" is not a tuple.
+  --> lib.cairo:22:29
+   |
+22 |                     println!("Multiple invisible characters detected at index {}: {}", index, ch.escape_unicode());
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+error: Missing variable in pattern.
+  --> lib.cairo:22:29
+   |
+22 |                     println!("Multiple invisible characters detected at index {}: {}", index, ch.escape_unicode());
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+error: Unsupported feature.
+  --> lib.cairo:22:115
+   |
+22 |                     println!("Multiple invisible characters detected at index {}: {}", index, ch.escape_unicode());
+   |                                                                                                                   ^
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+  --> lib.cairo:22:21
+   |
+22 |                     println!("Multiple invisible characters detected at index {}: {}", index, ch.escape_unicode());
+   |                     -------
+   |
+error: Missing semicolon
+  --> lib.cairo:28:14
+   |
+28 |             },
+   |              ^
+   |
+error: Identifier not found.
+  --> lib.cairo:30:13
+   |
+30 |             None => {
+   |             ^^^^
+   |
+error: Missing semicolon
+  --> lib.cairo:30:17
+   |
+30 |             None => {
+   |                 ^
+   |
+error: `break` only allowed inside a `loop`.
+  --> lib.cairo:32:17
+   |
+32 |                 break;
+   |                 ^^^^^^
+   |
+warning: Unused variable. Consider ignoring by prefixing with `_`.
+ --> lib.cairo:4:9
   |
-2 |     let mut a: Span<u32> = array![ 1,  2,  3,  4,  5 ].span();  // Extra spaces between elements
-  |                            ---------------------------
+4 |     let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
+  |         ---------------
   |
 
 //! > fixed
 fn main() {
-    let mut a: Span<u32> = array![1,2,3,4,5].span();  // Extra spaces between elements
+    let text = "Data\u{200B}:\u{2060}Value\u{FEFF}";
+    let invisible_chars = ['\u{200B}', '\u{2060}', '\u{FEFF}', '\u{00AD}', '\u{200C}', '\u{200D}'];
+
+    let mut index = 0;
+    let chars: Vec<char> = text.chars().collect();
+
     loop {
-        match a.pop_front() {
-            Option::Some(val) => println!("{val}"),
-            Option::None => { 
-                // Comment with space
+        match chars.get(index) {
+            Some(&ch) => {
+                if invisible_chars.contains(&ch) {
+                    println!("Multiple invisible characters detected at index {}: {}", index, ch.escape_unicode());
+                }
+                index += 1;
+            },
+            None => {
                 break;
             },
         }

--- a/crates/cairo-lint-core/tests/tests.rs
+++ b/crates/cairo-lint-core/tests/tests.rs
@@ -202,12 +202,10 @@ test_file!(manual, manual_is_some, "test basic is some", "test with comment in S
 test_file!(
     invisible_characters,
     invisible_characters,
-    "loop check invisible characters",
-    "loop check multiple invisible characters",
-    "loop check invisible characters in comments",
-    "loop check invisible characters in identifier",
-    "loop check invisible characters in URL",
-    "loop check invisible characters in filename",
-    "loop check invisible characters in number",
-    "loop check invisible characters in config"
+    "detect zero-width space",  
+    "detect zero-width joiner",
+    "detect byte order mark",
+    "detect paragraph separator",
+    "detect zero-width non-joiner",
+    "loop check for soft hyphen"
 );

--- a/crates/cairo-lint-core/tests/tests.rs
+++ b/crates/cairo-lint-core/tests/tests.rs
@@ -202,7 +202,7 @@ test_file!(manual, manual_is_some, "test basic is some", "test with comment in S
 test_file!(
     invisible_characters,
     invisible_characters,
-    "loop match pop front with spaces",
-    "loop match pop front with spaces in none",
-    "simple loop match pop front with comment and spaces"
+    "loop check invisible characters",
+    "loop check multiple invisible characters",
+    "loop check invisible characters in comments"
 );

--- a/crates/cairo-lint-core/tests/tests.rs
+++ b/crates/cairo-lint-core/tests/tests.rs
@@ -198,3 +198,11 @@ test_file!(
 );
 
 test_file!(manual, manual_is_some, "test basic is some", "test with comment in Some", "test with comment in None");
+
+test_file!(
+    invisible_characters,
+    invisible_characters,
+    "loop match pop front with spaces",
+    "loop match pop front with spaces in none",
+    "simple loop match pop front with comment and spaces"
+);

--- a/crates/cairo-lint-core/tests/tests.rs
+++ b/crates/cairo-lint-core/tests/tests.rs
@@ -204,5 +204,10 @@ test_file!(
     invisible_characters,
     "loop check invisible characters",
     "loop check multiple invisible characters",
-    "loop check invisible characters in comments"
+    "loop check invisible characters in comments",
+    "loop check invisible characters in identifier",
+    "loop check invisible characters in URL",
+    "loop check invisible characters in filename",
+    "loop check invisible characters in number",
+    "loop check invisible characters in config"
 );


### PR DESCRIPTION
This PR will add in invisible character detection functionality in code-expressions to the Cairo plugin.

**Invisible Character and Whitespaces detection:**

- The Function `check_invisible_characters` is implemented and performs the following checks in the `Expr`: 
- Whitespaces: a warning of (`Severity::Warning`) if present.
- Invisible characters: error (`Severity::Error`) on C-style  string literals like` \u{200B}`, `\u{00AD}`, `\u{200C}`, `\u{200D}`, `\u{202C}`, `\u{FEFF}`.

**Motivation:**

- The invisible kind of characters, like `zero-width space`, can create bugs that are impossible to trace in the code. This change enables the detection of such unwanted characters and possibly a warning/blocking their usage in code to guarantee the quality of source code.

**Diagnostic Messages Add following two diagnostic messages:**

- "Whitespace detected.": Whenever whitespace is detected.
- "Invisible character detected.": When invisible characters are detected.
 
