### PR TITLE
refactor: manual lint for Result and manual result expect 

### DIFF
--- a/crates/cairo-lint-core/src/fix.rs
+++ b/crates/cairo-lint-core/src/fix.rs
@@ -566,6 +566,14 @@ fn expr_match_get_var_name_and_err(expr_match: ExprMatch, db: &dyn SyntaxGroup) 
                     }
                     _ => panic!("Expected a function call expression"),
                 },
+                "Result::Err" => match second_arm.expression(db) {
+                    Expr::FunctionCall(func_call) => {
+                        let args = func_call.arguments(db).arguments(db).elements(db);
+                        let arg = args.first().expect("Should have arg");
+                        arg.as_syntax_node().get_text_without_trivia(db).to_string()
+                    }
+                    _ => panic!("Expected a function call expression"),
+                },
                 _ => panic!("Expected Option::None enum pattern"),
             }
         }

--- a/crates/cairo-lint-core/src/lints/manual/helpers.rs
+++ b/crates/cairo-lint-core/src/lints/manual/helpers.rs
@@ -1,0 +1,73 @@
+use cairo_lang_syntax::node::ast::{
+    BlockOrIf, Condition, Expr, ExprBlock, ExprIf, OptionElseClause, OptionPatternEnumInnerPattern, Pattern, Statement,
+};
+use cairo_lang_syntax::node::db::SyntaxGroup;
+use cairo_lang_syntax::node::TypedSyntaxNode;
+
+pub fn statement_check_func_name(statement: Statement, db: &dyn SyntaxGroup, func_names: &[&str]) -> bool {
+    match statement {
+        Statement::Expr(statement_expr) => {
+            let expr = statement_expr.expr(db);
+            if let Expr::FunctionCall(func_call) = expr {
+                let func_name = func_call.path(db).as_syntax_node().get_text_without_trivia(db);
+                func_names.contains(&func_name.as_str())
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+pub fn pattern_check_enum_arg(pattern: &Pattern, db: &dyn SyntaxGroup, arg_name: String) -> bool {
+    match pattern {
+        Pattern::Enum(enum_pattern) => {
+            let enum_arg = enum_pattern.pattern(db);
+            match enum_arg {
+                OptionPatternEnumInnerPattern::PatternEnumInnerPattern(inner_pattern) => {
+                    inner_pattern.pattern(db).as_syntax_node().get_text_without_trivia(db) == arg_name
+                }
+                OptionPatternEnumInnerPattern::Empty(_) => false,
+            }
+        }
+        _ => false,
+    }
+}
+
+pub fn expr_check_inner_pattern_is_if_block_statement(expr: &ExprIf, db: &dyn SyntaxGroup) -> bool {
+    if let Condition::Let(condition_let) = expr.condition(db) {
+        match &condition_let.patterns(db).elements(db)[0] {
+            Pattern::Enum(enum_pattern) => {
+                let enum_arg = enum_pattern.pattern(db);
+                match enum_arg {
+                    OptionPatternEnumInnerPattern::PatternEnumInnerPattern(inner_pattern) => {
+                        inner_pattern.pattern(db).as_syntax_node().get_text_without_trivia(db)
+                            == expr.if_block(db).statements(db).as_syntax_node().get_text_without_trivia(db)
+                    }
+                    OptionPatternEnumInnerPattern::Empty(_) => false,
+                }
+            }
+            _ => false,
+        }
+    } else {
+        false
+    }
+}
+
+pub fn arm_expr_check_func_name(arm_expression: Expr, db: &dyn SyntaxGroup, func_name: &str) -> bool {
+    if let Expr::FunctionCall(func_call) = arm_expression {
+        func_call.path(db).as_syntax_node().get_text(db) == func_name
+    } else {
+        false
+    }
+}
+
+pub fn get_else_expr_block(else_clause: OptionElseClause, db: &dyn SyntaxGroup) -> Option<ExprBlock> {
+    match else_clause {
+        OptionElseClause::Empty(_) => None,
+        OptionElseClause::ElseClause(else_clause) => match else_clause.else_block_or_if(db) {
+            BlockOrIf::Block(expr_block) => Some(expr_block),
+            _ => None,
+        },
+    }
+}

--- a/crates/cairo-lint-core/src/lints/manual/helpers.rs
+++ b/crates/cairo-lint-core/src/lints/manual/helpers.rs
@@ -53,9 +53,8 @@ pub fn pattern_check_enum_arg(pattern: &Pattern, db: &dyn SyntaxGroup, arg_name:
     }
 }
 
-/// Checks if the condition of the `ExprIf` expression is a `ConditionLet`, then checks that the
-/// pattern of the expression is an `Enum` and contains an inner pattern that is the same as the
-/// statement in the if block
+/// Checks that the condition expression contains an `Enum` that contains an inner pattern that is
+/// the same as the statement in the if block
 ///
 /// # Arguments
 /// * `expr` - The ExprIf expression to check.

--- a/crates/cairo-lint-core/src/lints/manual/helpers.rs
+++ b/crates/cairo-lint-core/src/lints/manual/helpers.rs
@@ -4,6 +4,16 @@ use cairo_lang_syntax::node::ast::{
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::TypedSyntaxNode;
 
+/// Checks if the input statement is a `FunctionCall` then checks if the function name is one of the
+/// func_names input list.
+///
+/// # Arguments
+/// * `statement` - A statement that may contain a `FunctionCall`.
+/// * `db` - Reference to the `SyntaxGroup` for syntax tree access.
+/// * `func_names` - A list of target function names.
+///
+/// # Returns
+/// * `true` if the function name matches any of the input names, otherwise `false`.
 pub fn statement_check_func_name(statement: Statement, db: &dyn SyntaxGroup, func_names: &[&str]) -> bool {
     match statement {
         Statement::Expr(statement_expr) => {
@@ -19,6 +29,15 @@ pub fn statement_check_func_name(statement: Statement, db: &dyn SyntaxGroup, fun
     }
 }
 
+/// Checks if the inner_pattern in the input `Pattern::Enum` matches the given argument name.
+///
+/// # Arguments
+/// * `pattern` - The pattern to check.
+/// * `db` - Reference to the `SyntaxGroup` for syntax tree access.
+/// * `arg_name` - The target name.
+///
+/// # Returns
+/// * `true` if the argument name matches, otherwise `false`.
 pub fn pattern_check_enum_arg(pattern: &Pattern, db: &dyn SyntaxGroup, arg_name: String) -> bool {
     match pattern {
         Pattern::Enum(enum_pattern) => {
@@ -34,6 +53,16 @@ pub fn pattern_check_enum_arg(pattern: &Pattern, db: &dyn SyntaxGroup, arg_name:
     }
 }
 
+/// Checks if the condition of the `ExprIf` expression is a `ConditionLet`, then checks that the
+/// pattern of the expression is an `Enum` and contains an inner pattern that is the same as the
+/// statement in the if block
+///
+/// # Arguments
+/// * `expr` - The ExprIf expression to check.
+/// * `db` - Reference to the `SyntaxGroup` for syntax tree access.
+///
+/// # Returns
+/// * `true` if the pattern matches the if block statement, otherwise `false`.
 pub fn expr_check_inner_pattern_is_if_block_statement(expr: &ExprIf, db: &dyn SyntaxGroup) -> bool {
     if let Condition::Let(condition_let) = expr.condition(db) {
         match &condition_let.patterns(db).elements(db)[0] {
@@ -54,6 +83,15 @@ pub fn expr_check_inner_pattern_is_if_block_statement(expr: &ExprIf, db: &dyn Sy
     }
 }
 
+/// Checks if the input `Expr` is a `FunctionCall` with the specified function name.
+///
+/// # Arguments
+/// * `arm_expression` - The expression to check.
+/// * `db` - Reference to the `SyntaxGroup` for syntax tree access.
+/// * `func_name` - The target function name.
+///
+/// # Returns
+/// * `true` if the expression is a function call and the function name matches, otherwise `false`.
 pub fn arm_expr_check_func_name(arm_expression: Expr, db: &dyn SyntaxGroup, func_name: &str) -> bool {
     if let Expr::FunctionCall(func_call) = arm_expression {
         func_call.path(db).as_syntax_node().get_text(db) == func_name
@@ -62,6 +100,14 @@ pub fn arm_expr_check_func_name(arm_expression: Expr, db: &dyn SyntaxGroup, func
     }
 }
 
+/// Retrieves the else `ExprBlock` from an `OptionElseClause` clause if it's non-empty.
+///
+/// # Arguments
+/// * `else_clause` - The `OptionElseClause` to extract the block from.
+/// * `db` - Reference to the `SyntaxGroup` for syntax tree access.
+///
+/// # Returns
+/// * `Some(ExprBlock)` if an `else` block exists, otherwise `None`.
 pub fn get_else_expr_block(else_clause: OptionElseClause, db: &dyn SyntaxGroup) -> Option<ExprBlock> {
     match else_clause {
         OptionElseClause::Empty(_) => None,

--- a/crates/cairo-lint-core/src/lints/manual/manual_expect.rs
+++ b/crates/cairo-lint-core/src/lints/manual/manual_expect.rs
@@ -9,7 +9,15 @@ use crate::lints::manual::{check_manual, check_manual_if, ManualLint};
 pub const MANUAL_EXPECT: &str = "Manual match for expect detected. Consider using `expect()` instead";
 
 pub fn check_manual_expect(db: &dyn SyntaxGroup, expr_match: &ExprMatch, diagnostics: &mut Vec<PluginDiagnostic>) {
-    if check_manual(db, expr_match, ManualLint::ManualExpect) {
+    if check_manual(db, expr_match, ManualLint::ManualOptExpect) {
+        diagnostics.push(PluginDiagnostic {
+            stable_ptr: expr_match.as_syntax_node().stable_ptr(),
+            message: MANUAL_EXPECT.to_owned(),
+            severity: Severity::Warning,
+        });
+    }
+
+    if check_manual(db, expr_match, ManualLint::ManualResExpect) {
         diagnostics.push(PluginDiagnostic {
             stable_ptr: expr_match.as_syntax_node().stable_ptr(),
             message: MANUAL_EXPECT.to_owned(),
@@ -19,7 +27,15 @@ pub fn check_manual_expect(db: &dyn SyntaxGroup, expr_match: &ExprMatch, diagnos
 }
 
 pub fn check_manual_if_expect(db: &dyn SyntaxGroup, expr_if: &ExprIf, diagnostics: &mut Vec<PluginDiagnostic>) {
-    if check_manual_if(db, expr_if, ManualLint::ManualExpect) {
+    if check_manual_if(db, expr_if, ManualLint::ManualOptExpect) {
+        diagnostics.push(PluginDiagnostic {
+            stable_ptr: expr_if.as_syntax_node().stable_ptr(),
+            message: MANUAL_EXPECT.to_owned(),
+            severity: Severity::Warning,
+        });
+    }
+
+    if check_manual_if(db, expr_if, ManualLint::ManualResExpect) {
         diagnostics.push(PluginDiagnostic {
             stable_ptr: expr_if.as_syntax_node().stable_ptr(),
             message: MANUAL_EXPECT.to_owned(),

--- a/crates/cairo-lint-core/src/lints/manual/mod.rs
+++ b/crates/cairo-lint-core/src/lints/manual/mod.rs
@@ -32,7 +32,7 @@ pub fn check_manual(db: &dyn SyntaxGroup, expr_match: &ExprMatch, manual_lint: M
         Pattern::Enum(enum_pattern) => {
             let enum_name = enum_pattern.path(db).as_syntax_node().get_text_without_trivia(db);
             match enum_name.as_str() {
-                "Option::Some" => check_syntax_some_arm(first_arm, db, manual_lint.clone()),
+                "Option::Some" => check_syntax_some_arm(first_arm, db, manual_lint),
                 "Result::Ok" => check_syntax_ok_arm(first_arm, db, manual_lint),
                 _ => return false,
             }
@@ -44,7 +44,7 @@ pub fn check_manual(db: &dyn SyntaxGroup, expr_match: &ExprMatch, manual_lint: M
         Pattern::Enum(enum_pattern) => {
             let enum_name = enum_pattern.path(db).as_syntax_node().get_text_without_trivia(db);
             match enum_name.as_str() {
-                "Option::None" => check_syntax_none_arm(second_arm.expression(db), db, manual_lint.clone()),
+                "Option::None" => check_syntax_none_arm(second_arm.expression(db), db, manual_lint),
                 "Result::Err" => check_syntax_err_arm(second_arm, db, manual_lint),
                 _ => return false,
             }

--- a/crates/cairo-lint-core/src/lints/manual/mod.rs
+++ b/crates/cairo-lint-core/src/lints/manual/mod.rs
@@ -4,8 +4,8 @@ pub mod manual_is_some;
 pub mod manual_ok_or;
 
 use cairo_lang_syntax::node::ast::{
-    BlockOrIf, Condition, Expr, ExprBlock, ExprIf, ExprMatch, MatchArm, OptionElseClause,
-    OptionPatternEnumInnerPattern, Pattern, Statement,
+    BlockOrIf, Condition, Expr, ExprIf, ExprMatch, MatchArm, OptionElseClause, OptionPatternEnumInnerPattern, Pattern,
+    Statement,
 };
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::TypedSyntaxNode;
@@ -15,8 +15,10 @@ pub enum ManualLint {
     ManualOkOr,
     ManualIsSome,
     ManualIsNone,
-    ManualExpect,
+    ManualOptExpect,
+    ManualResExpect,
 }
+
 pub fn check_manual(db: &dyn SyntaxGroup, expr_match: &ExprMatch, manual_lint: ManualLint) -> bool {
     let arms = expr_match.arms(db).elements(db);
 
@@ -27,128 +29,183 @@ pub fn check_manual(db: &dyn SyntaxGroup, expr_match: &ExprMatch, manual_lint: M
     let first_arm = &arms[0];
     let second_arm = &arms[1];
 
-    let found_some = match &first_arm.patterns(db).elements(db)[0] {
+    let found_first_arm = match &first_arm.patterns(db).elements(db)[0] {
         Pattern::Enum(enum_pattern) => {
             let enum_name = enum_pattern.path(db).as_syntax_node().get_text_without_trivia(db);
             match enum_name.as_str() {
-                "Option::Some" => check_syntax_some_arm(first_arm, db, manual_lint),
-                _ => false,
+                "Option::Some" => check_syntax_some_arm(first_arm, db, manual_lint.clone()),
+                "Result::Ok" => check_syntax_ok_arm(first_arm, db, manual_lint),
+                _ => return false,
             }
         }
-        _ => false,
+        _ => return false,
     };
 
-    let found_none = match &second_arm.patterns(db).elements(db)[0] {
+    let found_second_arm = match &second_arm.patterns(db).elements(db)[0] {
         Pattern::Enum(enum_pattern) => {
             let enum_name = enum_pattern.path(db).as_syntax_node().get_text_without_trivia(db);
             match enum_name.as_str() {
-                "Option::None" => check_syntax_none_expression(second_arm.expression(db), db, manual_lint),
-                _ => false,
+                "Option::None" => check_syntax_none_arm(second_arm.expression(db), db, manual_lint.clone()),
+                "Result::Err" => check_syntax_err_arm(second_arm, db, manual_lint),
+                _ => return false,
             }
         }
-        _ => false,
+        _ => return false,
     };
 
-    found_some && found_none
+    found_first_arm && found_second_arm
 }
 
 fn check_syntax_some_arm(arm: &MatchArm, db: &dyn SyntaxGroup, manual_lint: ManualLint) -> bool {
     match manual_lint {
         ManualLint::ManualOkOr => {
             if let Expr::FunctionCall(func_call) = arm.expression(db) {
-                return func_call.path(db).as_syntax_node().get_text(db) == "Result::Ok";
+                func_call.path(db).as_syntax_node().get_text(db) == "Result::Ok"
+            } else {
+                false
             }
         }
-        ManualLint::ManualIsSome => {
-            return arm.expression(db).as_syntax_node().get_text_without_trivia(db) == "true";
-        }
-        ManualLint::ManualIsNone => {
-            return arm.expression(db).as_syntax_node().get_text_without_trivia(db) == "false";
-        }
-        ManualLint::ManualExpect => match &arm.patterns(db).elements(db)[0] {
+        ManualLint::ManualIsSome => arm.expression(db).as_syntax_node().get_text_without_trivia(db) == "true",
+        ManualLint::ManualIsNone => arm.expression(db).as_syntax_node().get_text_without_trivia(db) == "false",
+        ManualLint::ManualOptExpect => match &arm.patterns(db).elements(db)[0] {
             Pattern::Enum(enum_pattern) => {
                 let enum_arg = enum_pattern.pattern(db);
                 match enum_arg {
                     OptionPatternEnumInnerPattern::PatternEnumInnerPattern(x) => {
-                        return x.pattern(db).as_syntax_node().get_text_without_trivia(db)
-                            == arm.expression(db).as_syntax_node().get_text_without_trivia(db);
+                        x.pattern(db).as_syntax_node().get_text_without_trivia(db)
+                            == arm.expression(db).as_syntax_node().get_text_without_trivia(db)
                     }
-                    OptionPatternEnumInnerPattern::Empty(_) => {
-                        return false;
-                    }
+                    OptionPatternEnumInnerPattern::Empty(_) => false,
                 }
             }
-            _ => {
-                return false;
-            }
+            _ => false,
         },
+        _ => false,
     }
-    false
 }
 
-fn check_syntax_none_expression(arm_expression: Expr, db: &dyn SyntaxGroup, manual_lint: ManualLint) -> bool {
+fn check_syntax_ok_arm(arm: &MatchArm, db: &dyn SyntaxGroup, manual_lint: ManualLint) -> bool {
+    match manual_lint {
+        ManualLint::ManualResExpect => match &arm.patterns(db).elements(db)[0] {
+            Pattern::Enum(enum_pattern) => {
+                let enum_arg = enum_pattern.pattern(db);
+                match enum_arg {
+                    OptionPatternEnumInnerPattern::PatternEnumInnerPattern(x) => {
+                        x.pattern(db).as_syntax_node().get_text_without_trivia(db)
+                            == arm.expression(db).as_syntax_node().get_text_without_trivia(db)
+                    }
+                    OptionPatternEnumInnerPattern::Empty(_) => false,
+                }
+            }
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
+fn check_syntax_none_arm(arm_expression: Expr, db: &dyn SyntaxGroup, manual_lint: ManualLint) -> bool {
     match manual_lint {
         ManualLint::ManualOkOr => {
             if let Expr::FunctionCall(func_call) = arm_expression {
-                return func_call.path(db).as_syntax_node().get_text(db) == "Result::Err";
+                func_call.path(db).as_syntax_node().get_text(db) == "Result::Err"
+            } else {
+                false
             }
         }
-        ManualLint::ManualIsSome => {
-            return arm_expression.as_syntax_node().get_text_without_trivia(db) == "false";
-        }
-        ManualLint::ManualIsNone => {
-            return arm_expression.as_syntax_node().get_text_without_trivia(db) == "true";
-        }
-        ManualLint::ManualExpect => {
+        ManualLint::ManualIsSome => arm_expression.as_syntax_node().get_text_without_trivia(db) == "false",
+        ManualLint::ManualIsNone => arm_expression.as_syntax_node().get_text_without_trivia(db) == "true",
+        ManualLint::ManualOptExpect => {
             if let Expr::FunctionCall(func_call) = arm_expression {
                 let func_name = func_call.path(db).as_syntax_node().get_text(db);
 
-                return func_name == "core::panic_with_felt252" || func_name == "panic_with_felt252";
+                func_name == "core::panic_with_felt252" || func_name == "panic_with_felt252"
             } else {
-                return false;
+                false
             }
         }
+        _ => false,
     }
+}
 
-    false
+fn check_syntax_err_arm(arm: &MatchArm, db: &dyn SyntaxGroup, manual_lint: ManualLint) -> bool {
+    match manual_lint {
+        ManualLint::ManualResExpect => {
+            if let Expr::FunctionCall(func_call) = arm.expression(db) {
+                let func_name = func_call.path(db).as_syntax_node().get_text(db);
+
+                let func_arg = match &arm.patterns(db).elements(db)[0] {
+                    Pattern::Enum(enum_pattern) => {
+                        let enum_arg = enum_pattern.pattern(db);
+                        match enum_arg {
+                            OptionPatternEnumInnerPattern::PatternEnumInnerPattern(inner_pattern) => {
+                                inner_pattern.pattern(db).as_syntax_node().get_text_without_trivia(db)
+                            }
+                            OptionPatternEnumInnerPattern::Empty(_) => {
+                                return false;
+                            }
+                        }
+                    }
+                    _ => {
+                        return false;
+                    }
+                };
+
+                (func_name == "core::panic_with_felt252" || func_name == "panic_with_felt252") && func_arg == "_"
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
 }
 
 pub fn check_manual_if(db: &dyn SyntaxGroup, expr: &ExprIf, manual_lint: ManualLint) -> bool {
-    let found_some = if let Condition::Let(condition_let) = expr.condition(db) {
+    let found_option = if let Condition::Let(condition_let) = expr.condition(db) {
         match &condition_let.patterns(db).elements(db)[0] {
             Pattern::Enum(enum_pattern) => {
                 let enum_name = enum_pattern.path(db).as_syntax_node().get_text_without_trivia(db);
                 match enum_name.as_str() {
-                    "Option::Some" => true,
-                    _ => {
-                        return false;
+                    "Option::Some" => {
+                        let found_if = check_syntax_opt_if(expr, db, manual_lint);
+
+                        let found_else = check_syntax_opt_else(expr, db, manual_lint);
+
+                        found_if && found_else
                     }
+                    _ => false,
                 }
             }
-            _ => {
-                return false;
-            }
+            _ => false,
         }
     } else {
-        return false;
+        false
     };
 
-    let found_if = check_syntax_if(expr, db, manual_lint);
+    let found_result = if let Condition::Let(condition_let) = expr.condition(db) {
+        match &condition_let.patterns(db).elements(db)[0] {
+            Pattern::Enum(enum_pattern) => {
+                let enum_name = enum_pattern.path(db).as_syntax_node().get_text_without_trivia(db);
+                match enum_name.as_str() {
+                    "Result::Ok" => {
+                        let found_if = check_syntax_res_if(expr, db, manual_lint);
 
-    let found_else = match expr.else_clause(db) {
-        OptionElseClause::Empty(_) => false,
-        OptionElseClause::ElseClause(else_clase) => match else_clase.else_block_or_if(db) {
-            BlockOrIf::Block(expr_block) => check_syntax_else(expr_block, db, manual_lint),
-            _ => {
-                return false;
+                        let found_else = check_syntax_res_else(expr, db, manual_lint);
+
+                        found_if && found_else
+                    }
+                    _ => false,
+                }
             }
-        },
+            _ => false,
+        }
+    } else {
+        false
     };
 
-    found_some && found_if && found_else
+    found_option || found_result
 }
 
-fn check_syntax_if(expr: &ExprIf, db: &dyn SyntaxGroup, manual_lint: ManualLint) -> bool {
+fn check_syntax_opt_if(expr: &ExprIf, db: &dyn SyntaxGroup, manual_lint: ManualLint) -> bool {
     match manual_lint {
         ManualLint::ManualOkOr => {
             let statement = expr.if_block(db).statements(db).elements(db)[0].clone();
@@ -157,8 +214,7 @@ fn check_syntax_if(expr: &ExprIf, db: &dyn SyntaxGroup, manual_lint: ManualLint)
                 Statement::Expr(statement_expr) => {
                     let expr = statement_expr.expr(db);
                     if let Expr::FunctionCall(func_call) = expr {
-                        let func_name: String =
-                            func_call.path(db).as_syntax_node().get_text(db).chars().filter(|&c| c != ' ').collect();
+                        let func_name: String = func_call.path(db).as_syntax_node().get_text_without_trivia(db);
 
                         func_name == "Result::Ok"
                     } else {
@@ -174,7 +230,7 @@ fn check_syntax_if(expr: &ExprIf, db: &dyn SyntaxGroup, manual_lint: ManualLint)
         ManualLint::ManualIsNone => {
             expr.if_block(db).statements(db).as_syntax_node().get_text_without_trivia(db) == "false"
         }
-        ManualLint::ManualExpect => {
+        ManualLint::ManualOptExpect => {
             if let Condition::Let(condition_let) = expr.condition(db) {
                 match &condition_let.patterns(db).elements(db)[0] {
                     Pattern::Enum(enum_pattern) => {
@@ -193,10 +249,47 @@ fn check_syntax_if(expr: &ExprIf, db: &dyn SyntaxGroup, manual_lint: ManualLint)
                 false
             }
         }
+        _ => false,
     }
 }
 
-fn check_syntax_else(expr_block: ExprBlock, db: &dyn SyntaxGroup, manual_lint: ManualLint) -> bool {
+fn check_syntax_res_if(expr: &ExprIf, db: &dyn SyntaxGroup, manual_lint: ManualLint) -> bool {
+    match manual_lint {
+        ManualLint::ManualResExpect => {
+            if let Condition::Let(condition_let) = expr.condition(db) {
+                match &condition_let.patterns(db).elements(db)[0] {
+                    Pattern::Enum(enum_pattern) => {
+                        let enum_arg = enum_pattern.pattern(db);
+                        match enum_arg {
+                            OptionPatternEnumInnerPattern::PatternEnumInnerPattern(inner_pattern) => {
+                                inner_pattern.pattern(db).as_syntax_node().get_text_without_trivia(db)
+                                    == expr.if_block(db).statements(db).as_syntax_node().get_text_without_trivia(db)
+                            }
+                            OptionPatternEnumInnerPattern::Empty(_) => false,
+                        }
+                    }
+                    _ => false,
+                }
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+fn check_syntax_opt_else(expr: &ExprIf, db: &dyn SyntaxGroup, manual_lint: ManualLint) -> bool {
+    let expr_block = match expr.else_clause(db) {
+        OptionElseClause::Empty(_) => {
+            return false;
+        }
+        OptionElseClause::ElseClause(else_clase) => match else_clase.else_block_or_if(db) {
+            BlockOrIf::Block(expr_block) => expr_block,
+            _ => {
+                return false;
+            }
+        },
+    };
     match manual_lint {
         ManualLint::ManualOkOr => {
             let statement = expr_block.statements(db).elements(db)[0].clone();
@@ -216,7 +309,7 @@ fn check_syntax_else(expr_block: ExprBlock, db: &dyn SyntaxGroup, manual_lint: M
         }
         ManualLint::ManualIsSome => expr_block.statements(db).as_syntax_node().get_text_without_trivia(db) == "false",
         ManualLint::ManualIsNone => expr_block.statements(db).as_syntax_node().get_text_without_trivia(db) == "true",
-        ManualLint::ManualExpect => {
+        ManualLint::ManualOptExpect => {
             let statement = expr_block.statements(db).elements(db)[0].clone();
 
             match statement {
@@ -232,5 +325,40 @@ fn check_syntax_else(expr_block: ExprBlock, db: &dyn SyntaxGroup, manual_lint: M
                 _ => false,
             }
         }
+        _ => false,
+    }
+}
+
+fn check_syntax_res_else(expr: &ExprIf, db: &dyn SyntaxGroup, manual_lint: ManualLint) -> bool {
+    let expr_block = match expr.else_clause(db) {
+        OptionElseClause::Empty(_) => {
+            return false;
+        }
+        OptionElseClause::ElseClause(else_clase) => match else_clase.else_block_or_if(db) {
+            BlockOrIf::Block(expr_block) => expr_block,
+            _ => {
+                return false;
+            }
+        },
+    };
+    match manual_lint {
+        ManualLint::ManualResExpect => {
+            let statement = expr_block.statements(db).elements(db)[0].clone();
+
+            match statement {
+                Statement::Expr(statement_expr) => {
+                    let expr = statement_expr.expr(db);
+                    if let Expr::FunctionCall(func_call) = expr {
+                        let func_name: String = func_call.path(db).as_syntax_node().get_text_without_trivia(db);
+
+                        func_name == "core::panic_with_felt252" || func_name == "panic_with_felt252"
+                    } else {
+                        false
+                    }
+                }
+                _ => false,
+            }
+        }
+        _ => false,
     }
 }

--- a/crates/cairo-lint-core/tests/test_files/manual/manual_expect
+++ b/crates/cairo-lint-core/tests/test_files/manual/manual_expect
@@ -262,4 +262,91 @@ fn main() {
     };
 }
 
+//! > ==========================================================================
 
+//! > test manual result if
+
+//! > cairo_code
+fn main() {
+    let res_val: Result<i32> = Result::Err('err');
+    let _a = if let Result::Ok(x) = res_val {
+        x
+    } else {
+        core::panic_with_felt252('err')
+    };
+}
+
+//! > diagnostics
+
+warning: Plugin diagnostic: Manual match for expect detected. Consider using `expect()` instead
+ --> lib.cairo:4:14
+  |
+4 |       let _a = if let Result::Ok(x) = res_val {
+  |  ______________-
+5 | |         x
+6 | |     } else {
+7 | |         core::panic_with_felt252('err')
+8 | |     };
+  | |_____-
+  |
+
+//! > fixed
+fn main() {
+    let res_val: Result<i32> = Result::Err('err');
+    let _a = res_val.expect('err');
+}
+
+//! > ==========================================================================
+
+//! > test manual match result
+
+//! > cairo_code
+fn main() {
+    let res_val: Result<i32> = Result::Err('err');
+    let _a = match res_val {
+        Result::Ok(val) => val,
+        Result::Err(_) => core::panic_with_felt252('error')
+    };
+}
+
+//! > diagnostics
+warning: Plugin diagnostic: Manual match for expect detected. Consider using `expect()` instead
+ --> lib.cairo:4:14
+  |
+4 |       let _a = match res_val {
+  |  ______________-
+5 | |         Result::Ok(val) => val,
+6 | |         Result::Err(_) => core::panic_with_felt252('error')
+7 | |     };
+  | |_____-
+  |
+
+//! > fixed
+fn main() {
+    let res_val: Result<i32> = Result::Err('err');
+    let _a = res_val.expect('error');
+}
+
+//! > ==========================================================================
+
+//! > test manual match result with unwrapped error
+
+//! > cairo_code
+fn main() {
+    let res_val: Result<i32> = Result::Err('err');
+    let _a = match res_val {
+        Result::Ok(val) => val,
+        Result::Err(err) => core::panic_with_felt252(err)
+    };
+}
+
+//! > diagnostics
+
+//! > fixed
+fn main() {
+    let res_val: Result<i32> = Result::Err('err');
+    let _a = match res_val {
+        Result::Ok(val) => val,
+        Result::Err(err) => core::panic_with_felt252(err)
+    };
+}

--- a/crates/cairo-lint-core/tests/tests.rs
+++ b/crates/cairo-lint-core/tests/tests.rs
@@ -243,5 +243,8 @@ test_file!(
     "test with comment in None",
     "test match expression is a function",
     "test manual if",
-    "test manual if with additional instructions"
+    "test manual if with additional instructions",
+    "test manual result if",
+    "test manual match result",
+    "test manual match result with unwrapped error"
 );


### PR DESCRIPTION
* Refactor manual lints for the `Result` enum lints
* Implementation of the `manual_expect` lint for `Result` enum