### PR TITLE
feat: manual_ok and manual_err

### DIFF
--- a/crates/cairo-lint-core/src/fix.rs
+++ b/crates/cairo-lint-core/src/fix.rs
@@ -506,72 +506,32 @@ impl Fixer {
 
     /// Rewrites a manual implementation of is_some
     pub fn fix_manual_is_some(&self, db: &dyn SyntaxGroup, node: SyntaxNode) -> String {
-        fix_manual_is("is_some", db, node)
+        fix_manual("is_some", db, node)
     }
 
     // Rewrites a manual implementation of is_none
     pub fn fix_manual_is_none(&self, db: &dyn SyntaxGroup, node: SyntaxNode) -> String {
-        fix_manual_is("is_none", db, node)
+        fix_manual("is_none", db, node)
     }
 
     /// Rewrites a manual implementation of is_ok
     pub fn fix_manual_is_ok(&self, db: &dyn SyntaxGroup, node: SyntaxNode) -> String {
-        fix_manual_is("is_ok", db, node)
+        fix_manual("is_ok", db, node)
     }
 
     /// Rewrites a manual implementation of is_err
     pub fn fix_manual_is_err(&self, db: &dyn SyntaxGroup, node: SyntaxNode) -> String {
-        fix_manual_is("is_err", db, node)
+        fix_manual("is_err", db, node)
     }
 
     /// Rewrites a manual implementation of ok
     pub fn fix_manual_ok(&self, db: &dyn SyntaxGroup, node: SyntaxNode) -> String {
-        match node.kind(db) {
-            SyntaxKind::ExprMatch => {
-                let expr_match = ExprMatch::from_syntax_node(db, node.clone());
-
-                let option_var_name = expr_match.expr(db).as_syntax_node().get_text_without_trivia(db);
-
-                format!("{option_var_name}.ok()")
-            }
-            SyntaxKind::ExprIf => {
-                let expr_if = ExprIf::from_syntax_node(db, node.clone());
-
-                let var_name = if let Condition::Let(condition_let) = expr_if.condition(db) {
-                    condition_let.expr(db).as_syntax_node().get_text_without_trivia(db)
-                } else {
-                    panic!("Expected an ConditionLet condition")
-                };
-
-                format!("{var_name}.ok()")
-            }
-            _ => panic!("SyntaxKind should be either ExprIf or ExprMatch"),
-        }
+        fix_manual("ok", db, node)
     }
 
     /// Rewrites a manual implementation of err
     pub fn fix_manual_err(&self, db: &dyn SyntaxGroup, node: SyntaxNode) -> String {
-        match node.kind(db) {
-            SyntaxKind::ExprMatch => {
-                let expr_match = ExprMatch::from_syntax_node(db, node.clone());
-
-                let option_var_name = expr_match.expr(db).as_syntax_node().get_text_without_trivia(db);
-
-                format!("{option_var_name}.err()")
-            }
-            SyntaxKind::ExprIf => {
-                let expr_if = ExprIf::from_syntax_node(db, node.clone());
-
-                let var_name = if let Condition::Let(condition_let) = expr_if.condition(db) {
-                    condition_let.expr(db).as_syntax_node().get_text_without_trivia(db)
-                } else {
-                    panic!("Expected an ConditionLet condition")
-                };
-
-                format!("{var_name}.err()")
-            }
-            _ => panic!("SyntaxKind should be either ExprIf or ExprMatch"),
-        }
+        fix_manual("err", db, node)
     }
 
     /// Rewrites a manual implementation of expect
@@ -676,7 +636,7 @@ fn expr_if_get_var_name_and_err(expr_if: ExprIf, db: &dyn SyntaxGroup) -> (Strin
     (option_var_name, err)
 }
 
-pub fn fix_manual_is(func_name: &str, db: &dyn SyntaxGroup, node: SyntaxNode) -> String {
+pub fn fix_manual(func_name: &str, db: &dyn SyntaxGroup, node: SyntaxNode) -> String {
     match node.kind(db) {
         SyntaxKind::ExprMatch => {
             let expr_match = ExprMatch::from_syntax_node(db, node.clone());

--- a/crates/cairo-lint-core/src/lints/manual/helpers.rs
+++ b/crates/cairo-lint-core/src/lints/manual/helpers.rs
@@ -201,39 +201,32 @@ pub fn expr_check_condition_enum_inner_pattern_is_if_block_enum_inner_pattern(
     db: &dyn SyntaxGroup,
     enum_name: String,
 ) -> bool {
-    if let Condition::Let(condition_let) = expr.condition(db) {
-        match &condition_let.patterns(db).elements(db)[0] {
-            Pattern::Enum(enum_pattern) => {
-                let enum_arg = enum_pattern.pattern(db);
-                match enum_arg {
-                    OptionPatternEnumInnerPattern::PatternEnumInnerPattern(inner_pattern) => {
-                        match expr.if_block(db).statements(db).elements(db)[0].clone() {
-                            Statement::Expr(statement_expr) => {
-                                let expr = statement_expr.expr(db);
-                                if let Expr::FunctionCall(func_call) = expr {
-                                    if func_call.path(db).as_syntax_node().get_text_without_trivia(db) == enum_name {
-                                        inner_pattern.pattern(db).as_syntax_node().get_text_without_trivia(db)
-                                            == func_call.arguments(db).arguments(db).elements(db)[0]
-                                                .as_syntax_node()
-                                                .get_text_without_trivia(db)
-                                    } else {
-                                        false
-                                    }
-                                } else {
-                                    false
-                                }
-                            }
-                            _ => false,
-                        }
-                    }
-                    OptionPatternEnumInnerPattern::Empty(_) => false,
-                }
-            }
-            _ => false,
-        }
-    } else {
-        false
+    let Condition::Let(condition_let) = expr.condition(db) else {
+        return false;
+    };
+
+    let Pattern::Enum(enum_pattern) = &condition_let.patterns(db).elements(db)[0] else {
+        return false;
+    };
+
+    let OptionPatternEnumInnerPattern::PatternEnumInnerPattern(inner_pattern) = enum_pattern.pattern(db) else {
+        return false;
+    };
+
+    let Statement::Expr(statement_expr) = expr.if_block(db).statements(db).elements(db)[0].clone() else {
+        return false;
+    };
+
+    let Expr::FunctionCall(func_call) = statement_expr.expr(db) else {
+        return false;
+    };
+
+    if func_call.path(db).as_syntax_node().get_text_without_trivia(db) != enum_name {
+        return false;
     }
+
+    func_call.arguments(db).arguments(db).elements(db)[0].as_syntax_node().get_text_without_trivia(db)
+        == inner_pattern.pattern(db).as_syntax_node().get_text_without_trivia(db)
 }
 
 /// Checks if the input `Expr` is a default of the expr kind.

--- a/crates/cairo-lint-core/src/lints/manual/manual_err.rs
+++ b/crates/cairo-lint-core/src/lints/manual/manual_err.rs
@@ -1,0 +1,29 @@
+use cairo_lang_defs::plugin::PluginDiagnostic;
+use cairo_lang_diagnostics::Severity;
+use cairo_lang_syntax::node::ast::{ExprIf, ExprMatch};
+use cairo_lang_syntax::node::db::SyntaxGroup;
+use cairo_lang_syntax::node::TypedSyntaxNode;
+
+use crate::lints::manual::{check_manual, check_manual_if, ManualLint};
+
+pub const MANUAL_ERR: &str = "Manual match for `err` detected. Consider using `err()` instead";
+
+pub fn check_manual_err(db: &dyn SyntaxGroup, expr_match: &ExprMatch, diagnostics: &mut Vec<PluginDiagnostic>) {
+    if check_manual(db, expr_match, ManualLint::ManualErr) {
+        diagnostics.push(PluginDiagnostic {
+            stable_ptr: expr_match.as_syntax_node().stable_ptr(),
+            message: MANUAL_ERR.to_owned(),
+            severity: Severity::Warning,
+        });
+    }
+}
+
+pub fn check_manual_if_err(db: &dyn SyntaxGroup, expr_if: &ExprIf, diagnostics: &mut Vec<PluginDiagnostic>) {
+    if check_manual_if(db, expr_if, ManualLint::ManualErr) {
+        diagnostics.push(PluginDiagnostic {
+            stable_ptr: expr_if.as_syntax_node().stable_ptr(),
+            message: MANUAL_ERR.to_owned(),
+            severity: Severity::Warning,
+        });
+    }
+}

--- a/crates/cairo-lint-core/src/lints/manual/manual_ok.rs
+++ b/crates/cairo-lint-core/src/lints/manual/manual_ok.rs
@@ -1,0 +1,29 @@
+use cairo_lang_defs::plugin::PluginDiagnostic;
+use cairo_lang_diagnostics::Severity;
+use cairo_lang_syntax::node::ast::{ExprIf, ExprMatch};
+use cairo_lang_syntax::node::db::SyntaxGroup;
+use cairo_lang_syntax::node::TypedSyntaxNode;
+
+use crate::lints::manual::{check_manual, check_manual_if, ManualLint};
+
+pub const MANUAL_OK: &str = "Manual match for `ok` detected. Consider using `ok()` instead";
+
+pub fn check_manual_ok(db: &dyn SyntaxGroup, expr_match: &ExprMatch, diagnostics: &mut Vec<PluginDiagnostic>) {
+    if check_manual(db, expr_match, ManualLint::ManualOk) {
+        diagnostics.push(PluginDiagnostic {
+            stable_ptr: expr_match.as_syntax_node().stable_ptr(),
+            message: MANUAL_OK.to_owned(),
+            severity: Severity::Warning,
+        });
+    }
+}
+
+pub fn check_manual_if_ok(db: &dyn SyntaxGroup, expr_if: &ExprIf, diagnostics: &mut Vec<PluginDiagnostic>) {
+    if check_manual_if(db, expr_if, ManualLint::ManualOk) {
+        diagnostics.push(PluginDiagnostic {
+            stable_ptr: expr_if.as_syntax_node().stable_ptr(),
+            message: MANUAL_OK.to_owned(),
+            severity: Severity::Warning,
+        });
+    }
+}

--- a/crates/cairo-lint-core/src/plugin.rs
+++ b/crates/cairo-lint-core/src/plugin.rs
@@ -41,6 +41,8 @@ pub enum CairoLintKind {
     Panic,
     ErasingOperation,
     ManualOkOr,
+    ManualOk,
+    ManualErr,
     ManualIsSome,
     ManualIsNone,
     ManualIsOk,
@@ -67,6 +69,8 @@ pub fn diagnostic_kind_from_message(message: &str) -> CairoLintKind {
         loop_for_while::LOOP_FOR_WHILE => CairoLintKind::LoopForWhile,
         erasing_op::ERASING_OPERATION => CairoLintKind::ErasingOperation,
         manual_ok_or::MANUAL_OK_OR => CairoLintKind::ManualOkOr,
+        manual_ok::MANUAL_OK => CairoLintKind::ManualOk,
+        manual_err::MANUAL_ERR => CairoLintKind::ManualErr,
         bitwise_for_parity_check::BITWISE_FOR_PARITY => CairoLintKind::BitwiseForParityCheck,
         manual_is::MANUAL_IS_SOME => CairoLintKind::ManualIsSome,
         manual_is::MANUAL_IS_NONE => CairoLintKind::ManualIsNone,
@@ -138,6 +142,16 @@ impl AnalyzerPlugin for CairoLint {
                             &ExprIf::from_syntax_node(db.upcast(), node.clone()),
                             &mut diags,
                         );
+                        manual_ok::check_manual_if_ok(
+                            db.upcast(),
+                            &ExprIf::from_syntax_node(db.upcast(), node.clone()),
+                            &mut diags,
+                        );
+                        manual_err::check_manual_if_err(
+                            db.upcast(),
+                            &ExprIf::from_syntax_node(db.upcast(), node.clone()),
+                            &mut diags,
+                        );
                         manual_unwrap_or_default::check_manual_if_unwrap_or_default(
                             db.upcast(),
                             &ExprIf::from_syntax_node(db.upcast(), node.clone()),
@@ -168,6 +182,16 @@ impl AnalyzerPlugin for CairoLint {
                     }
                     SyntaxKind::ExprMatch => {
                         manual_ok_or::check_manual_ok_or(
+                            db.upcast(),
+                            &ExprMatch::from_syntax_node(db.upcast(), node.clone()),
+                            &mut diags,
+                        );
+                        manual_ok::check_manual_ok(
+                            db.upcast(),
+                            &ExprMatch::from_syntax_node(db.upcast(), node.clone()),
+                            &mut diags,
+                        );
+                        manual_err::check_manual_err(
                             db.upcast(),
                             &ExprMatch::from_syntax_node(db.upcast(), node.clone()),
                             &mut diags,

--- a/crates/cairo-lint-core/tests/test_files/manual/manual_err
+++ b/crates/cairo-lint-core/tests/test_files/manual/manual_err
@@ -1,0 +1,118 @@
+//! > test basic err
+
+//! > cairo_code
+fn main() {
+    let foo: Result<i32> = Result::Err('err');
+    let _foo = match foo {
+        Result::Ok(_) => Option::None,
+        Result::Err(x) => Option::Some(x),
+    };
+}
+
+//! > diagnostics
+
+warning: Plugin diagnostic: Manual match for `err` detected. Consider using `err()` instead
+ --> lib.cairo:4:16
+  |
+4 |       let _foo = match foo {
+  |  ________________-
+5 | |         Result::Ok(_) => Option::None,
+6 | |         Result::Err(x) => Option::Some(x),
+7 | |     };
+  | |_____-
+  |
+
+//! > fixed
+fn main() {
+    let foo: Result<i32> = Result::Err('err');
+    let _foo = foo.err();
+}
+
+//! > ==========================================================================
+
+//! > test basic if err
+
+//! > cairo_code
+fn main() {
+    let res_val: Result<i32> = Result::Err('err');
+    let _a = if let Result::Err(x) = res_val {
+        Option::Some(x)
+    } else {
+        Option::None
+    };
+}
+
+//! > diagnostics
+
+warning: Plugin diagnostic: Manual match for `err` detected. Consider using `err()` instead
+ --> lib.cairo:4:14
+  |
+4 |       let _a = if let Result::Err(x) = res_val {
+  |  ______________-
+5 | |         Option::Some(x)
+6 | |     } else {
+7 | |         Option::None
+8 | |     };
+  | |_____-
+  |
+
+//! > fixed
+fn main() {
+    let res_val: Result<i32> = Result::Err('err');
+    let _a = res_val.err();
+}
+
+//! > ==========================================================================
+
+//! > test other err
+
+//! > cairo_code
+fn main() {
+    let foo: Result<i32> = Result::Err('err');
+    let other_err = 'other err';
+    let _foo = match foo {
+        Result::Ok(_) => Option::None,
+        Result::Err(_) => Option::Some(other_err),
+    };
+}
+
+//! > diagnostics
+
+//! > fixed
+fn main() {
+    let foo: Result<i32> = Result::Err('err');
+    let other_err = 'other err';
+    let _foo = match foo {
+        Result::Ok(_) => Option::None,
+        Result::Err(_) => Option::Some(other_err),
+    };
+}
+
+//! > ==========================================================================
+
+//! > test if other err
+
+//! > cairo_code
+fn main() {
+    let res_val: Result<i32> = Result::Err('err');
+    let other_err = 'err';
+    let _a = if let Result::Err(_) = res_val {
+        Option::Some(other_err)
+    } else {
+        Option::None
+    };
+}
+
+//! > diagnostics
+
+//! > fixed
+fn main() {
+    let res_val: Result<i32> = Result::Err('err');
+    let other_err = 'err';
+    let _a = if let Result::Err(_) = res_val {
+        Option::Some(other_err)
+    } else {
+        Option::None
+    };
+}
+

--- a/crates/cairo-lint-core/tests/test_files/manual/manual_ok
+++ b/crates/cairo-lint-core/tests/test_files/manual/manual_ok
@@ -1,0 +1,118 @@
+//! > test basic ok
+
+//! > cairo_code
+fn main() {
+    let res_val: Result<i32> = Result::Err('err');
+    let _a = match res_val {
+        Result::Ok(x) => Option::Some(x),
+        Result::Err(_) => Option::None,
+    };
+}
+
+//! > diagnostics
+
+warning: Plugin diagnostic: Manual match for `ok` detected. Consider using `ok()` instead
+ --> lib.cairo:4:14
+  |
+4 |       let _a = match res_val {
+  |  ______________-
+5 | |         Result::Ok(x) => Option::Some(x),
+6 | |         Result::Err(_) => Option::None,
+7 | |     };
+  | |_____-
+  |
+
+//! > fixed
+fn main() {
+    let res_val: Result<i32> = Result::Err('err');
+    let _a = res_val.ok();
+}
+
+//! > ==========================================================================
+
+//! > test basic if ok
+
+//! > cairo_code
+fn main() {
+    let res_val: Result<i32> = Result::Err('err');
+    let _a = if let Result::Ok(x) = res_val {
+        Option::Some(x)
+    } else {
+        Option::None
+    };
+}
+
+//! > diagnostics
+
+warning: Plugin diagnostic: Manual match for `ok` detected. Consider using `ok()` instead
+ --> lib.cairo:4:14
+  |
+4 |       let _a = if let Result::Ok(x) = res_val {
+  |  ______________-
+5 | |         Option::Some(x)
+6 | |     } else {
+7 | |         Option::None
+8 | |     };
+  | |_____-
+  |
+
+//! > fixed
+fn main() {
+    let res_val: Result<i32> = Result::Err('err');
+    let _a = res_val.ok();
+}
+
+//! > ==========================================================================
+
+//! > test other var
+
+//! > cairo_code
+fn main() {
+    let res_val: Result<i32> = Result::Err('err');
+    let other_val = 0;
+    let _a = match res_val {
+        Result::Ok(_) => Option::Some(other_val),
+        Result::Err(_) => Option::None,
+    };
+}
+
+//! > diagnostics
+
+//! > fixed
+fn main() {
+    let res_val: Result<i32> = Result::Err('err');
+    let other_val = 0;
+    let _a = match res_val {
+        Result::Ok(_) => Option::Some(other_val),
+        Result::Err(_) => Option::None,
+    };
+}
+
+//! > ==========================================================================
+
+//! > test if other var
+
+//! > cairo_code
+fn main() {
+    let res_val: Result<i32> = Result::Err('err');
+    let other_val = 0;
+    let _a = if let Result::Ok(_) = res_val {
+        Option::Some(other_val)
+    } else {
+        Option::None
+    };
+}
+
+//! > diagnostics
+
+//! > fixed
+fn main() {
+    let res_val: Result<i32> = Result::Err('err');
+    let other_val = 0;
+    let _a = if let Result::Ok(_) = res_val {
+        Option::Some(other_val)
+    } else {
+        Option::None
+    };
+}
+

--- a/crates/cairo-lint-core/tests/test_files/manual/manual_ok_or
+++ b/crates/cairo-lint-core/tests/test_files/manual/manual_ok_or
@@ -228,3 +228,57 @@ fn main() {
         Result::Err('err')
     };
 }
+
+//! > ==========================================================================
+
+//! > test other var
+
+//! > cairo_code
+fn main() {
+    let foo: Option<i32> = Option::None;
+    let other_val = 0;
+    let _foo = match foo {
+        Option::Some(_) => Result::Ok(other_val),
+        Option::None => Result::Err('this is an err'),
+    };
+}
+
+//! > diagnostics
+
+//! > fixed
+fn main() {
+    let foo: Option<i32> = Option::None;
+    let other_val = 0;
+    let _foo = match foo {
+        Option::Some(_) => Result::Ok(other_val),
+        Option::None => Result::Err('this is an err'),
+    };
+}
+
+//! > ==========================================================================
+
+//! > test if other var
+
+//! > cairo_code
+fn main() {
+    let opt_val: Option<i32> = Option::None;
+    let other_val = 0;
+    let _a = if let Option::Some(_) = opt_val {
+        Result::Ok(other_val)
+    } else {
+        Result::Err('err')
+    };
+}
+
+//! > diagnostics
+
+//! > fixed
+fn main() {
+    let opt_val: Option<i32> = Option::None;
+    let other_val = 0;
+    let _a = if let Option::Some(_) = opt_val {
+        Result::Ok(other_val)
+    } else {
+        Result::Err('err')
+    };
+}

--- a/crates/cairo-lint-core/tests/tests.rs
+++ b/crates/cairo-lint-core/tests/tests.rs
@@ -212,7 +212,9 @@ test_file!(
     "test with comment in Some",
     "test match expression not a variable",
     "test manual if",
-    "test manual if with additional instructions"
+    "test manual if with additional instructions",
+    "test other var",
+    "test if other var"
 );
 
 test_file!(
@@ -306,3 +308,7 @@ test_file!(
     "test manual if",
     "test manual if expression is a function"
 );
+
+test_file!(manual, manual_ok, "test basic ok", "test basic if ok", "test other var", "test if other var");
+
+test_file!(manual, manual_err, "test basic err", "test basic if err", "test other err", "test if other err");


### PR DESCRIPTION
* Implementation of `manual_ok` and `manual_err` lints
* Modification of `manual_ok_or` to avoid fixing code incorrectly

Incorrect behaviour modified : 

this :
```rust
fn main() {
    let foo: Option<i32> = Option::None;
    let other_val = 0;
    let _foo = match foo {
        Option::Some(_) => Result::Ok(other_val),
        Option::None => Result::Err('this is an err'),
    };
}
```

was incorrectly fixed to this :
```rust
fn main() {
    let foo: Option<i32> = Option::None;
    let other_val = 0;
    let _foo = foo.ok_or('this is an err')
}
```